### PR TITLE
SASS-6213: Save and continue irrecoverableDebts

### DIFF
--- a/app/controllers/JourneyAnswersController.scala
+++ b/app/controllers/JourneyAnswersController.scala
@@ -57,8 +57,7 @@ class JourneyAnswersController @Inject() (auth: AuthorisedAction,
   }
 
   def saveIncomeAnswers(taxYear: TaxYear, businessId: BusinessId, nino: Nino): Action[AnyContent] = auth.async { implicit user =>
-    getBody[IncomeJourneyAnswers](user) { value =>
-      val ctx = JourneyContextWithNino(taxYear, businessId, user.getMtditid, nino)
+    getBodyWithCtx[IncomeJourneyAnswers](taxYear, businessId, nino) { (ctx, value) =>
       incomeService.saveAnswers(ctx, value).map(_ => NoContent)
     }
   }
@@ -79,8 +78,7 @@ class JourneyAnswersController @Inject() (auth: AuthorisedAction,
   }
 
   def saveExpensesTailoringTotalAmount(taxYear: TaxYear, businessId: BusinessId, nino: Nino): Action[AnyContent] = auth.async { implicit user =>
-    getBody[AsOneTotalAnswers](user) { value =>
-      val ctx = JourneyContextWithNino(taxYear, businessId, user.getMtditid, nino)
+    getBodyWithCtx[AsOneTotalAnswers](taxYear, businessId, nino) { (ctx, value) =>
       for {
         _ <- expensesService.saveAnswers(ctx, value)
         _ <- expensesService.persistAnswers(businessId, taxYear, user.getMtditid, ExpensesCategoriesDb(ExpensesTailoring.TotalAmount))
@@ -89,8 +87,7 @@ class JourneyAnswersController @Inject() (auth: AuthorisedAction,
   }
 
   def saveGoodsToSellOrUse(taxYear: TaxYear, businessId: BusinessId, nino: Nino): Action[AnyContent] = auth.async { implicit user =>
-    getBody[GoodsToSellOrUseJourneyAnswers](user) { value =>
-      val ctx = JourneyContextWithNino(taxYear, businessId, user.getMtditid, nino)
+    getBodyWithCtx[GoodsToSellOrUseJourneyAnswers](taxYear, businessId, nino) { (ctx, value) =>
       expensesService.saveAnswers(ctx, value).map(_ => NoContent)
     }
   }
@@ -104,8 +101,7 @@ class JourneyAnswersController @Inject() (auth: AuthorisedAction,
   }
 
   def saveOfficeSupplies(taxYear: TaxYear, businessId: BusinessId, nino: Nino): Action[AnyContent] = auth.async { implicit user =>
-    getBody[OfficeSuppliesJourneyAnswers](user) { value =>
-      val ctx = JourneyContextWithNino(taxYear, businessId, user.getMtditid, nino)
+    getBodyWithCtx[OfficeSuppliesJourneyAnswers](taxYear, businessId, nino) { (ctx, value) =>
       expensesService.saveAnswers(ctx, value).map(_ => NoContent)
     }
   }
@@ -116,8 +112,7 @@ class JourneyAnswersController @Inject() (auth: AuthorisedAction,
   }
 
   def saveRepairsAndMaintenanceCosts(taxYear: TaxYear, businessId: BusinessId, nino: Nino): Action[AnyContent] = auth.async { implicit user =>
-    getBody[RepairsAndMaintenanceCostsJourneyAnswers](user) { value =>
-      val ctx = JourneyContextWithNino(taxYear, businessId, user.getMtditid, nino)
+    getBodyWithCtx[RepairsAndMaintenanceCostsJourneyAnswers](taxYear, businessId, nino) { (ctx, value) =>
       expensesService.saveAnswers(ctx, value).map(_ => NoContent)
     }
   }
@@ -127,8 +122,7 @@ class JourneyAnswersController @Inject() (auth: AuthorisedAction,
   }
 
   def saveStaffCosts(taxYear: TaxYear, businessId: BusinessId, nino: Nino): Action[AnyContent] = auth.async { implicit user =>
-    getBody[StaffCostsJourneyAnswers](user) { value =>
-      val ctx = JourneyContextWithNino(taxYear, businessId, user.getMtditid, nino)
+    getBodyWithCtx[StaffCostsJourneyAnswers](taxYear, businessId, nino) { (ctx, value) =>
       expensesService.saveAnswers(ctx, value).map(_ => NoContent)
     }
   }
@@ -140,8 +134,7 @@ class JourneyAnswersController @Inject() (auth: AuthorisedAction,
   }
 
   def saveAdvertisingOrMarketing(taxYear: TaxYear, businessId: BusinessId, nino: Nino): Action[AnyContent] = auth.async { implicit user =>
-    getBody[AdvertisingOrMarketingJourneyAnswers](user) { value =>
-      val ctx = JourneyContextWithNino(taxYear, businessId, user.getMtditid, nino)
+    getBodyWithCtx[AdvertisingOrMarketingJourneyAnswers](taxYear, businessId, nino) { (ctx, value) =>
       expensesService.saveAnswers(ctx, value).map(_ => NoContent)
     }
   }
@@ -151,8 +144,7 @@ class JourneyAnswersController @Inject() (auth: AuthorisedAction,
   }
 
   def saveEntertainmentCosts(taxYear: TaxYear, businessId: BusinessId, nino: Nino): Action[AnyContent] = auth.async { implicit user =>
-    getBody[EntertainmentJourneyAnswers](user) { value =>
-      val ctx = JourneyContextWithNino(taxYear, businessId, user.getMtditid, nino)
+    getBodyWithCtx[EntertainmentJourneyAnswers](taxYear, businessId, nino) { (ctx, value) =>
       expensesService.saveAnswers(ctx, value).map(_ => NoContent)
     }
   }
@@ -162,8 +154,7 @@ class JourneyAnswersController @Inject() (auth: AuthorisedAction,
   }
 
   def saveConstructionCosts(taxYear: TaxYear, businessId: BusinessId, nino: Nino): Action[AnyContent] = auth.async { implicit user =>
-    getBody[ConstructionJourneyAnswers](user) { value =>
-      val ctx = JourneyContextWithNino(taxYear, businessId, user.getMtditid, nino)
+    getBodyWithCtx[ConstructionJourneyAnswers](taxYear, businessId, nino) { (ctx, value) =>
       expensesService.saveAnswers(ctx, value).map(_ => NoContent)
     }
   }
@@ -173,8 +164,7 @@ class JourneyAnswersController @Inject() (auth: AuthorisedAction,
   }
 
   def saveProfessionalFees(taxYear: TaxYear, businessId: BusinessId, nino: Nino): Action[AnyContent] = auth.async { implicit user =>
-    getBody[ProfessionalFeesJourneyAnswers](user) { value =>
-      val ctx = JourneyContextWithNino(taxYear, businessId, user.getMtditid, nino)
+    getBodyWithCtx[ProfessionalFeesJourneyAnswers](taxYear, businessId, nino) { (ctx, value) =>
       expensesService.saveAnswers(ctx, value).map(_ => NoContent)
     }
   }
@@ -184,8 +174,7 @@ class JourneyAnswersController @Inject() (auth: AuthorisedAction,
   }
 
   def saveInterest(taxYear: TaxYear, businessId: BusinessId, nino: Nino): Action[AnyContent] = auth.async { implicit user =>
-    getBody[InterestJourneyAnswers](user) { value =>
-      val ctx = JourneyContextWithNino(taxYear, businessId, user.getMtditid, nino)
+    getBodyWithCtx[InterestJourneyAnswers](taxYear, businessId, nino) { (ctx, value) =>
       expensesService.saveAnswers(ctx, value).map(_ => NoContent)
     }
   }
@@ -195,8 +184,7 @@ class JourneyAnswersController @Inject() (auth: AuthorisedAction,
   }
 
   def saveDepreciationCosts(taxYear: TaxYear, businessId: BusinessId, nino: Nino): Action[AnyContent] = auth.async { implicit user =>
-    getBody[DepreciationCostsJourneyAnswers](user) { value =>
-      val ctx = JourneyContextWithNino(taxYear, businessId, user.getMtditid, nino)
+    getBodyWithCtx[DepreciationCostsJourneyAnswers](taxYear, businessId, nino) { (ctx, value) =>
       expensesService.saveAnswers(ctx, value).map(_ => NoContent)
     }
   }
@@ -206,8 +194,7 @@ class JourneyAnswersController @Inject() (auth: AuthorisedAction,
   }
 
   def saveOtherExpenses(taxYear: TaxYear, businessId: BusinessId, nino: Nino): Action[AnyContent] = auth.async { implicit user =>
-    getBody[OtherExpensesJourneyAnswers](user) { value =>
-      val ctx = JourneyContextWithNino(taxYear, businessId, user.getMtditid, nino)
+    getBodyWithCtx[OtherExpensesJourneyAnswers](taxYear, businessId, nino) { (ctx, value) =>
       expensesService.saveAnswers(ctx, value).map(_ => NoContent)
     }
   }
@@ -217,14 +204,19 @@ class JourneyAnswersController @Inject() (auth: AuthorisedAction,
   }
 
   def saveFinancialCharges(taxYear: TaxYear, businessId: BusinessId, nino: Nino): Action[AnyContent] = auth.async { implicit user =>
-    getBody[FinancialChargesJourneyAnswers](user) { value =>
-      val ctx = JourneyContextWithNino(taxYear, businessId, user.getMtditid, nino)
+    getBodyWithCtx[FinancialChargesJourneyAnswers](taxYear, businessId, nino) { (ctx, value) =>
       expensesService.saveAnswers(ctx, value).map(_ => NoContent)
     }
   }
 
   def getIrrecoverableDebts(taxYear: TaxYear, businessId: BusinessId, nino: Nino): Action[AnyContent] = auth.async { implicit user =>
     handleApiResultT(expensesService.getAnswers[IrrecoverableDebtsJourneyAnswers](JourneyContextWithNino(taxYear, businessId, user.getMtditid, nino)))
+  }
+
+  def saveIrrecoverableDebts(taxYear: TaxYear, businessId: BusinessId, nino: Nino): Action[AnyContent] = auth.async { implicit user =>
+    getBodyWithCtx[IrrecoverableDebtsJourneyAnswers](taxYear, businessId, nino) { (ctx, value) =>
+      expensesService.saveAnswers(ctx, value).map(_ => NoContent)
+    }
   }
 
 }

--- a/app/models/connector/Api1786ExpensesResponseParser.scala
+++ b/app/models/connector/Api1786ExpensesResponseParser.scala
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package parsers.expenses
+package models.connector
 
-import models.connector._
 import models.connector.api_1786.SuccessResponseSchema
 import models.frontend.expenses.advertisingOrMarketing.AdvertisingOrMarketingJourneyAnswers
 import models.frontend.expenses.construction.ConstructionJourneyAnswers
@@ -34,103 +33,103 @@ import models.frontend.expenses.staffcosts.StaffCostsJourneyAnswers
 import models.frontend.expenses.tailoring.ExpensesTailoringAnswers
 import utils.ResponseParser
 
-trait ExpensesResponseParser[Result] extends ResponseParser[api_1786.SuccessResponseSchema, Result] {
+trait Api1786ExpensesResponseParser[Result] extends ResponseParser[api_1786.SuccessResponseSchema, Result] {
   override def parse(response: api_1786.SuccessResponseSchema): Result
 }
 
-object ExpensesResponseParser {
+object Api1786ExpensesResponseParser {
 
   private val noneFound = 0 // TODO: What if it's None?
 
-  implicit val goodsToSellOrUseParser: ExpensesResponseParser[GoodsToSellOrUseJourneyAnswers] =
+  implicit val goodsToSellOrUseParser: Api1786ExpensesResponseParser[GoodsToSellOrUseJourneyAnswers] =
     (response: SuccessResponseSchema) =>
       GoodsToSellOrUseJourneyAnswers(
         goodsToSellOrUseAmount = response.financials.deductions.flatMap(_.costOfGoods.map(_.amount)).getOrElse(noneFound),
         disallowableGoodsToSellOrUseAmount = response.financials.deductions.flatMap(_.costOfGoods.flatMap(_.disallowableAmount))
       )
 
-  implicit val repairsAndMaintenanceCostsParser: ExpensesResponseParser[RepairsAndMaintenanceCostsJourneyAnswers] =
+  implicit val repairsAndMaintenanceCostsParser: Api1786ExpensesResponseParser[RepairsAndMaintenanceCostsJourneyAnswers] =
     (response: SuccessResponseSchema) =>
       RepairsAndMaintenanceCostsJourneyAnswers(
         repairsAndMaintenanceAmount = response.financials.deductions.flatMap(_.maintenanceCosts.map(_.amount)).getOrElse(noneFound),
         repairsAndMaintenanceDisallowableAmount = response.financials.deductions.flatMap(_.maintenanceCosts.flatMap(_.disallowableAmount))
       )
 
-  implicit val entertainmentCostsParser: ExpensesResponseParser[EntertainmentJourneyAnswers] =
+  implicit val entertainmentCostsParser: Api1786ExpensesResponseParser[EntertainmentJourneyAnswers] =
     (response: SuccessResponseSchema) =>
       EntertainmentJourneyAnswers(
         entertainmentAmount = response.financials.deductions.flatMap(_.businessEntertainmentCosts.map(_.amount)).getOrElse(noneFound)
       )
 
-  implicit val officeSuppliesParser: ExpensesResponseParser[OfficeSuppliesJourneyAnswers] =
+  implicit val officeSuppliesParser: Api1786ExpensesResponseParser[OfficeSuppliesJourneyAnswers] =
     (response: SuccessResponseSchema) =>
       OfficeSuppliesJourneyAnswers(
         officeSuppliesAmount = response.financials.deductions.flatMap(_.adminCosts.map(_.amount)).getOrElse(noneFound),
         officeSuppliesDisallowableAmount = response.financials.deductions.flatMap(_.adminCosts.flatMap(_.disallowableAmount))
       )
 
-  implicit val constructionParser: ExpensesResponseParser[ConstructionJourneyAnswers] =
+  implicit val constructionParser: Api1786ExpensesResponseParser[ConstructionJourneyAnswers] =
     (response: SuccessResponseSchema) =>
       ConstructionJourneyAnswers(
         constructionIndustryAmount = response.financials.deductions.flatMap(_.constructionIndustryScheme.map(_.amount)).getOrElse(noneFound),
         constructionIndustryDisallowableAmount = response.financials.deductions.flatMap(_.constructionIndustryScheme.flatMap(_.disallowableAmount))
       )
 
-  implicit val professionalFeesParser: ExpensesResponseParser[ProfessionalFeesJourneyAnswers] =
+  implicit val professionalFeesParser: Api1786ExpensesResponseParser[ProfessionalFeesJourneyAnswers] =
     (response: SuccessResponseSchema) =>
       ProfessionalFeesJourneyAnswers(
         professionalFeesAmount = response.financials.deductions.flatMap(_.professionalFees.map(_.amount)).getOrElse(noneFound),
         professionalFeesDisallowableAmount = response.financials.deductions.flatMap(_.professionalFees.flatMap(_.disallowableAmount))
       )
 
-  implicit val interestParser: ExpensesResponseParser[InterestJourneyAnswers] =
+  implicit val interestParser: Api1786ExpensesResponseParser[InterestJourneyAnswers] =
     (response: SuccessResponseSchema) =>
       InterestJourneyAnswers(
         interestAmount = response.financials.deductions.flatMap(_.interest.map(_.amount)).getOrElse(noneFound),
         interestDisallowableAmount = response.financials.deductions.flatMap(_.interest.flatMap(_.disallowableAmount))
       )
 
-  implicit val staffCostsParser: ExpensesResponseParser[StaffCostsJourneyAnswers] =
+  implicit val staffCostsParser: Api1786ExpensesResponseParser[StaffCostsJourneyAnswers] =
     (response: SuccessResponseSchema) =>
       StaffCostsJourneyAnswers(
         staffCostsAmount = response.financials.deductions.flatMap(_.staffCosts.map(_.amount)).getOrElse(noneFound),
         staffCostsDisallowableAmount = response.financials.deductions.flatMap(_.staffCosts.flatMap(_.disallowableAmount))
       )
 
-  implicit val depreciationCostsParser: ExpensesResponseParser[DepreciationCostsJourneyAnswers] =
+  implicit val depreciationCostsParser: Api1786ExpensesResponseParser[DepreciationCostsJourneyAnswers] =
     (response: SuccessResponseSchema) =>
       DepreciationCostsJourneyAnswers(
         depreciationDisallowableAmount = response.financials.deductions.flatMap(_.depreciation.map(_.amount)).getOrElse(noneFound)
       )
 
-  implicit val asOneTotalAnswersParser: ExpensesResponseParser[ExpensesTailoringAnswers.AsOneTotalAnswers] =
+  implicit val asOneTotalAnswersParser: Api1786ExpensesResponseParser[ExpensesTailoringAnswers.AsOneTotalAnswers] =
     (response: SuccessResponseSchema) =>
       ExpensesTailoringAnswers.AsOneTotalAnswers(
         response.financials.deductions.flatMap(_.simplifiedExpenses).getOrElse(noneFound)
       )
 
-  implicit val advertisingOrMarketingParser: ExpensesResponseParser[AdvertisingOrMarketingJourneyAnswers] =
+  implicit val advertisingOrMarketingParser: Api1786ExpensesResponseParser[AdvertisingOrMarketingJourneyAnswers] =
     (response: SuccessResponseSchema) =>
       AdvertisingOrMarketingJourneyAnswers(
         advertisingOrMarketingAmount = response.financials.deductions.flatMap(_.advertisingCosts.map(_.amount)).getOrElse(noneFound),
         advertisingOrMarketingDisallowableAmount = response.financials.deductions.flatMap(_.advertisingCosts.flatMap(_.disallowableAmount))
       )
 
-  implicit val financialChargesParser: ExpensesResponseParser[FinancialChargesJourneyAnswers] =
+  implicit val financialChargesParser: Api1786ExpensesResponseParser[FinancialChargesJourneyAnswers] =
     (response: SuccessResponseSchema) =>
       FinancialChargesJourneyAnswers(
         financialChargesAmount = response.financials.deductions.flatMap(_.financialCharges.map(_.amount)).getOrElse(noneFound),
         financialChargesDisallowableAmount = response.financials.deductions.flatMap(_.financialCharges.flatMap(_.disallowableAmount))
       )
 
-  implicit val otherExpensesParser: ExpensesResponseParser[OtherExpensesJourneyAnswers] =
+  implicit val otherExpensesParser: Api1786ExpensesResponseParser[OtherExpensesJourneyAnswers] =
     (response: SuccessResponseSchema) =>
       OtherExpensesJourneyAnswers(
         otherExpensesAmount = response.financials.deductions.flatMap(_.other.map(_.amount)).getOrElse(noneFound),
         otherExpensesDisallowableAmount = response.financials.deductions.flatMap(_.other.flatMap(_.disallowableAmount))
       )
 
-  implicit val irrecoverableDebtsParser: ExpensesResponseParser[IrrecoverableDebtsJourneyAnswers] =
+  implicit val irrecoverableDebtsParser: Api1786ExpensesResponseParser[IrrecoverableDebtsJourneyAnswers] =
     (response: SuccessResponseSchema) =>
       IrrecoverableDebtsJourneyAnswers(
         irrecoverableDebtsAmount = response.financials.deductions.flatMap(_.badDebt.map(_.amount)).getOrElse(noneFound),

--- a/app/models/connector/Api1894DeductionsBuilder.scala
+++ b/app/models/connector/Api1894DeductionsBuilder.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package utils
+package models.connector
 
 import models.connector.api_1894.request._
 import models.frontend.expenses.advertisingOrMarketing.AdvertisingOrMarketingJourneyAnswers
@@ -24,6 +24,7 @@ import models.frontend.expenses.entertainment.EntertainmentJourneyAnswers
 import models.frontend.expenses.financialCharges.FinancialChargesJourneyAnswers
 import models.frontend.expenses.goodsToSellOrUse.GoodsToSellOrUseJourneyAnswers
 import models.frontend.expenses.interest.InterestJourneyAnswers
+import models.frontend.expenses.irrecoverableDebts.IrrecoverableDebtsJourneyAnswers
 import models.frontend.expenses.officeSupplies.OfficeSuppliesJourneyAnswers
 import models.frontend.expenses.otherExpenses.OtherExpensesJourneyAnswers
 import models.frontend.expenses.professionalFees.ProfessionalFeesJourneyAnswers
@@ -31,19 +32,21 @@ import models.frontend.expenses.repairsandmaintenance.RepairsAndMaintenanceCosts
 import models.frontend.expenses.staffcosts.StaffCostsJourneyAnswers
 import models.frontend.expenses.tailoring.ExpensesTailoringAnswers
 
-trait DeductionsBuilder[A] {
+trait Api1894DeductionsBuilder[A] {
   def build(answers: A): Deductions
 }
 
-object DeductionsBuilder {
+/** Set of converters which convert from a journey answer to a Downstream objects.
+  */
+object Api1894DeductionsBuilder {
 
-  implicit val expensesTotalAmount: DeductionsBuilder[ExpensesTailoringAnswers.AsOneTotalAnswers] =
+  implicit val expensesTotalAmount: Api1894DeductionsBuilder[ExpensesTailoringAnswers.AsOneTotalAnswers] =
     (answers: ExpensesTailoringAnswers.AsOneTotalAnswers) =>
       Deductions.empty.copy(
         simplifiedExpenses = Some(answers.totalAmount)
       )
 
-  implicit val goodsToSellOrUse: DeductionsBuilder[GoodsToSellOrUseJourneyAnswers] =
+  implicit val goodsToSellOrUse: Api1894DeductionsBuilder[GoodsToSellOrUseJourneyAnswers] =
     (answers: GoodsToSellOrUseJourneyAnswers) =>
       Deductions.empty.copy(
         costOfGoods = Some(
@@ -51,7 +54,7 @@ object DeductionsBuilder {
         )
       )
 
-  implicit val repairsAndMaintenanceCosts: DeductionsBuilder[RepairsAndMaintenanceCostsJourneyAnswers] =
+  implicit val repairsAndMaintenanceCosts: Api1894DeductionsBuilder[RepairsAndMaintenanceCostsJourneyAnswers] =
     (answers: RepairsAndMaintenanceCostsJourneyAnswers) =>
       Deductions.empty.copy(
         maintenanceCosts = Some(
@@ -59,7 +62,7 @@ object DeductionsBuilder {
         )
       )
 
-  implicit val advertisingOrMarketingCosts: DeductionsBuilder[AdvertisingOrMarketingJourneyAnswers] =
+  implicit val advertisingOrMarketingCosts: Api1894DeductionsBuilder[AdvertisingOrMarketingJourneyAnswers] =
     (answers: AdvertisingOrMarketingJourneyAnswers) =>
       Deductions.empty.copy(
         advertisingCosts = Some(
@@ -67,7 +70,7 @@ object DeductionsBuilder {
         )
       )
 
-  implicit val officeSupplies: DeductionsBuilder[OfficeSuppliesJourneyAnswers] =
+  implicit val officeSupplies: Api1894DeductionsBuilder[OfficeSuppliesJourneyAnswers] =
     (answers: OfficeSuppliesJourneyAnswers) =>
       Deductions.empty.copy(
         adminCosts = Some(
@@ -75,7 +78,7 @@ object DeductionsBuilder {
         )
       )
 
-  implicit val entertainmentCosts: DeductionsBuilder[EntertainmentJourneyAnswers] =
+  implicit val entertainmentCosts: Api1894DeductionsBuilder[EntertainmentJourneyAnswers] =
     (answers: EntertainmentJourneyAnswers) =>
       Deductions.empty.copy(
         businessEntertainmentCosts = Some(
@@ -83,7 +86,7 @@ object DeductionsBuilder {
         )
       )
 
-  implicit val staffCosts: DeductionsBuilder[StaffCostsJourneyAnswers] =
+  implicit val staffCosts: Api1894DeductionsBuilder[StaffCostsJourneyAnswers] =
     (answers: StaffCostsJourneyAnswers) =>
       Deductions.empty.copy(
         staffCosts = Some(
@@ -91,7 +94,7 @@ object DeductionsBuilder {
         )
       )
 
-  implicit val construction: DeductionsBuilder[ConstructionJourneyAnswers] =
+  implicit val construction: Api1894DeductionsBuilder[ConstructionJourneyAnswers] =
     (answers: ConstructionJourneyAnswers) =>
       Deductions.empty.copy(
         constructionIndustryScheme = Some(
@@ -99,7 +102,7 @@ object DeductionsBuilder {
         )
       )
 
-  implicit val professionalFees: DeductionsBuilder[ProfessionalFeesJourneyAnswers] =
+  implicit val professionalFees: Api1894DeductionsBuilder[ProfessionalFeesJourneyAnswers] =
     (answers: ProfessionalFeesJourneyAnswers) =>
       Deductions.empty.copy(
         professionalFees = Some(
@@ -107,7 +110,7 @@ object DeductionsBuilder {
         )
       )
 
-  implicit val interest: DeductionsBuilder[InterestJourneyAnswers] =
+  implicit val interest: Api1894DeductionsBuilder[InterestJourneyAnswers] =
     (answers: InterestJourneyAnswers) =>
       Deductions.empty.copy(
         interest = Some(
@@ -115,7 +118,7 @@ object DeductionsBuilder {
         )
       )
 
-  implicit val depreciationCosts: DeductionsBuilder[DepreciationCostsJourneyAnswers] =
+  implicit val depreciationCosts: Api1894DeductionsBuilder[DepreciationCostsJourneyAnswers] =
     (answers: DepreciationCostsJourneyAnswers) =>
       Deductions.empty.copy(
         depreciation = Some(
@@ -123,13 +126,18 @@ object DeductionsBuilder {
         )
       )
 
-  implicit val otherExpenses: DeductionsBuilder[OtherExpensesJourneyAnswers] =
+  implicit val otherExpenses: Api1894DeductionsBuilder[OtherExpensesJourneyAnswers] =
     (answers: OtherExpensesJourneyAnswers) =>
       Deductions.empty.copy(other =
         Some(SelfEmploymentDeductionsDetailType(Some(answers.otherExpensesAmount), answers.otherExpensesDisallowableAmount)))
 
-  implicit val financialCharges: DeductionsBuilder[FinancialChargesJourneyAnswers] =
+  implicit val financialCharges: Api1894DeductionsBuilder[FinancialChargesJourneyAnswers] =
     (answers: FinancialChargesJourneyAnswers) =>
       Deductions.empty.copy(financialCharges =
         Some(SelfEmploymentDeductionsDetailPosNegType(Some(answers.financialChargesAmount), answers.financialChargesDisallowableAmount)))
+
+  implicit val badDebt: Api1894DeductionsBuilder[IrrecoverableDebtsJourneyAnswers] =
+    (answers: IrrecoverableDebtsJourneyAnswers) =>
+      Deductions.empty.copy(badDebt =
+        Some(SelfEmploymentDeductionsDetailPosNegType(Some(answers.irrecoverableDebtsAmount), answers.irrecoverableDebtsDisallowableAmount)))
 }

--- a/app/models/connector/api_1894/request/FinancialsType.scala
+++ b/app/models/connector/api_1894/request/FinancialsType.scala
@@ -17,8 +17,8 @@
 package models.connector.api_1894.request
 
 import cats.implicits.catsSyntaxOptionId
+import models.connector.Api1894DeductionsBuilder
 import play.api.libs.json._
-import utils.DeductionsBuilder
 
 /** Represents the Swagger definition for financialsType.
   */
@@ -27,8 +27,8 @@ case class FinancialsType(incomes: Option[IncomesType], deductions: Option[Deduc
 object FinancialsType {
   implicit lazy val financialsTypeJsonFormat: Format[FinancialsType] = Json.format[FinancialsType]
 
-  def fromFrontendModel[A: DeductionsBuilder](answers: A): FinancialsType = {
-    val builder = implicitly[DeductionsBuilder[A]]
+  def fromFrontendModel[A: Api1894DeductionsBuilder](answers: A): FinancialsType = {
+    val builder = implicitly[Api1894DeductionsBuilder[A]]
     FinancialsType(None, builder.build(answers).some)
   }
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -55,3 +55,4 @@ GET         /:taxYear/:businessId/expenses-financial-charges/:nino/answers      
 POST        /:taxYear/:businessId/expenses-financial-charges/:nino/answers                                              controllers.JourneyAnswersController.saveFinancialCharges(taxYear: TaxYear, businessId: BusinessId, nino: Nino)
 
 GET         /:taxYear/:businessId/expenses-irrecoverable-debts/:nino/answers                                            controllers.JourneyAnswersController.getIrrecoverableDebts(taxYear: TaxYear, businessId: BusinessId, nino: Nino)
+POST        /:taxYear/:businessId/expenses-irrecoverable-debts/:nino/answers                                            controllers.JourneyAnswersController.saveIrrecoverableDebts(taxYear: TaxYear, businessId: BusinessId, nino: Nino)

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -106,11 +106,6 @@
             <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
         </parameters>
     </check>
-    <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
-        <parameters>
-            <parameter name="maxMethods"><![CDATA[30]]></parameter>
-        </parameters>
-    </check>
     <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>

--- a/test/controllers/JourneyAnswersControllerSpec.scala
+++ b/test/controllers/JourneyAnswersControllerSpec.scala
@@ -24,6 +24,7 @@ import gens.ExpensesTailoringAnswersGen._
 import gens.IncomeJourneyAnswersGen.incomeJourneyAnswersGen
 import gens.genOne
 import models.common.JourneyContextWithNino
+import models.connector.Api1786ExpensesResponseParser
 import models.domain.ApiResultT
 import models.error.ServiceError
 import models.frontend.expenses.advertisingOrMarketing.AdvertisingOrMarketingJourneyAnswers
@@ -43,7 +44,6 @@ import models.frontend.expenses.tailoring.ExpensesTailoringAnswers._
 import org.scalamock.handlers.CallHandler3
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-import parsers.expenses.ExpensesResponseParser
 import play.api.http.Status._
 import play.api.libs.json.Json
 import services.journeyAnswers.ExpensesAnswersService
@@ -446,6 +446,16 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
         methodBlock = () => controller.getIrrecoverableDebts(currTaxYear, businessId, nino)
       )
     }
+    s"Save answers and return a $NO_CONTENT when successful" in {
+      forAll(irrecoverableDebtsJourneyAnswersGen) { data =>
+        behave like testRoute(
+          request = buildRequest(data),
+          expectedStatus = NO_CONTENT,
+          expectedBody = "",
+          methodBlock = () => underTest.saveIrrecoverableDebts(currTaxYear, businessId, nino)
+        )
+      }
+    }
   }
 
   trait GetExpensesTest[T] {
@@ -459,9 +469,9 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
       expensesService = expensesService
     )
 
-    def mockExpensesService(): CallHandler3[JourneyContextWithNino, ExpensesResponseParser[T], HeaderCarrier, ApiResultT[T]] =
+    def mockExpensesService(): CallHandler3[JourneyContextWithNino, Api1786ExpensesResponseParser[T], HeaderCarrier, ApiResultT[T]] =
       (expensesService
-        .getAnswers(_: JourneyContextWithNino)(_: ExpensesResponseParser[T], _: HeaderCarrier))
+        .getAnswers(_: JourneyContextWithNino)(_: Api1786ExpensesResponseParser[T], _: HeaderCarrier))
         .expects(*, *, *)
         .returns(EitherT.right[ServiceError](Future.successful(journeyAnswers)))
 

--- a/test/gens/ExpensesJourneyAnswersGen.scala
+++ b/test/gens/ExpensesJourneyAnswersGen.scala
@@ -43,6 +43,8 @@ object ExpensesJourneyAnswersGen {
     disallowableAmount <- Gen.option(bigDecimalGen)
   } yield OfficeSuppliesJourneyAnswers(amount, disallowableAmount)
 
+  val entertainmentJourneyAnswersGen: Gen[EntertainmentJourneyAnswers] = bigDecimalGen.map(EntertainmentJourneyAnswers(_))
+
   val repairsAndMaintenanceCostsJourneyAnswersGen: Gen[RepairsAndMaintenanceCostsJourneyAnswers] = for {
     amount             <- bigDecimalGen
     disallowableAmount <- Gen.option(bigDecimalGen)
@@ -71,6 +73,8 @@ object ExpensesJourneyAnswersGen {
     amount             <- bigDecimalGen
     disallowableAmount <- Gen.option(bigDecimalGen)
   } yield ProfessionalFeesJourneyAnswers(amount, disallowableAmount)
+
+  val depreciationCostsJourneyAnswersGen: Gen[DepreciationCostsJourneyAnswers] = bigDecimalGen.map(DepreciationCostsJourneyAnswers(_))
 
   val interestJourneyAnswersGen: Gen[InterestJourneyAnswers] = for {
     amount             <- bigDecimalGen

--- a/test/models/common/connector/api_1894/request/FinancialsTypeSpec.scala
+++ b/test/models/common/connector/api_1894/request/FinancialsTypeSpec.scala
@@ -21,7 +21,7 @@ import gens.ExpensesJourneyAnswersGen._
 import models.connector.api_1894.request._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import utils.DeductionsBuilder.{goodsToSellOrUse, officeSupplies}
+import models.connector.Api1894DeductionsBuilder.{goodsToSellOrUse, officeSupplies}
 
 class FinancialsTypeSpec extends AnyWordSpec with Matchers {
 

--- a/test/models/connector/Api1894DeductionsBuilderSpec.scala
+++ b/test/models/connector/Api1894DeductionsBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/models/connector/Api1894DeductionsBuilderSpec.scala
+++ b/test/models/connector/Api1894DeductionsBuilderSpec.scala
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.connector
+
+import cats.implicits._
+import gens.ExpensesJourneyAnswersGen._
+import gens.{bigDecimalGen, genOne}
+import models.connector.api_1894.request.{
+  Deductions,
+  SelfEmploymentDeductionsDetailAllowablePosNegType,
+  SelfEmploymentDeductionsDetailPosNegType,
+  SelfEmploymentDeductionsDetailType
+}
+import models.frontend.expenses.advertisingOrMarketing.AdvertisingOrMarketingJourneyAnswers
+import models.frontend.expenses.construction.ConstructionJourneyAnswers
+import models.frontend.expenses.depreciation.DepreciationCostsJourneyAnswers
+import models.frontend.expenses.entertainment.EntertainmentJourneyAnswers
+import models.frontend.expenses.financialCharges.FinancialChargesJourneyAnswers
+import models.frontend.expenses.goodsToSellOrUse.GoodsToSellOrUseJourneyAnswers
+import models.frontend.expenses.interest.InterestJourneyAnswers
+import models.frontend.expenses.irrecoverableDebts.IrrecoverableDebtsJourneyAnswers
+import models.frontend.expenses.officeSupplies.OfficeSuppliesJourneyAnswers
+import models.frontend.expenses.otherExpenses.OtherExpensesJourneyAnswers
+import models.frontend.expenses.professionalFees.ProfessionalFeesJourneyAnswers
+import models.frontend.expenses.repairsandmaintenance.RepairsAndMaintenanceCostsJourneyAnswers
+import models.frontend.expenses.staffcosts.StaffCostsJourneyAnswers
+import models.frontend.expenses.tailoring.ExpensesTailoringAnswers.AsOneTotalAnswers
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class Api1894DeductionsBuilderSpec extends AnyWordSpecLike with TableDrivenPropertyChecks {
+  type PNT = SelfEmploymentDeductionsDetailPosNegType
+  type DT  = SelfEmploymentDeductionsDetailType
+
+  "build SelfEmploymentDeductionsDetailPosNegType" should {
+    val deductions = Deductions.empty
+    case class TestCase[A: Api1894DeductionsBuilder](answers: A, expected: Deductions) {
+      def actualDeductions: Deductions = implicitly[Api1894DeductionsBuilder[A]].build(answers)
+    }
+
+    val bigDecimal                               = genOne(bigDecimalGen)
+    val goodsToSellOrUseJourneyAnswers           = genOne(goodsToSellOrUseJourneyAnswersGen)
+    val repairsAndMaintenanceCostsJourneyAnswers = genOne(repairsAndMaintenanceCostsJourneyAnswersGen)
+    val advertisingOrMarketingJourneyAnswers     = genOne(advertisingOrMarketingJourneyAnswersGen)
+    val officeSuppliesJourneyAnswers             = genOne(officeSuppliesJourneyAnswersGen)
+    val entertainmentJourneyAnswers              = genOne(entertainmentJourneyAnswersGen)
+    val staffCostsJourneyAnswers                 = genOne(staffCostsJourneyAnswersGen)
+    val constructionJourneyAnswers               = genOne(constructionJourneyAnswersGen)
+    val professionalFeesJourneyAnswers           = genOne(professionalFeesJourneyAnswersGen)
+    val interestJourneyAnswers                   = genOne(interestJourneyAnswersGen)
+    val depreciationCostsJourneyAnswers          = genOne(depreciationCostsJourneyAnswersGen)
+    val otherExpensesJourneyAnswers              = genOne(otherExpensesJourneyAnswersGen)
+    val financialChargesJourneyAnswers           = genOne(financialChargesJourneyAnswersGen)
+    val irrecoverableDebtsJourneyAnswers         = genOne(irrecoverableDebtsJourneyAnswersGen)
+
+    val cases = Table(
+      "testCase",
+      TestCase[AsOneTotalAnswers](
+        AsOneTotalAnswers(bigDecimal),
+        deductions.copy(simplifiedExpenses = bigDecimal.some)
+      ),
+      TestCase[GoodsToSellOrUseJourneyAnswers](
+        goodsToSellOrUseJourneyAnswers,
+        deductions.copy(costOfGoods = new PNT(
+          goodsToSellOrUseJourneyAnswers.goodsToSellOrUseAmount.some,
+          goodsToSellOrUseJourneyAnswers.disallowableGoodsToSellOrUseAmount
+        ).some)
+      ),
+      TestCase[RepairsAndMaintenanceCostsJourneyAnswers](
+        repairsAndMaintenanceCostsJourneyAnswers,
+        deductions.copy(maintenanceCosts = new PNT(
+          repairsAndMaintenanceCostsJourneyAnswers.repairsAndMaintenanceAmount.some,
+          repairsAndMaintenanceCostsJourneyAnswers.repairsAndMaintenanceDisallowableAmount
+        ).some)
+      ),
+      TestCase[AdvertisingOrMarketingJourneyAnswers](
+        advertisingOrMarketingJourneyAnswers,
+        deductions.copy(advertisingCosts = new DT(
+          advertisingOrMarketingJourneyAnswers.advertisingOrMarketingAmount.some,
+          advertisingOrMarketingJourneyAnswers.advertisingOrMarketingDisallowableAmount
+        ).some)
+      ),
+      TestCase[OfficeSuppliesJourneyAnswers](
+        officeSuppliesJourneyAnswers,
+        deductions.copy(adminCosts = new DT(
+          officeSuppliesJourneyAnswers.officeSuppliesAmount.some,
+          officeSuppliesJourneyAnswers.officeSuppliesDisallowableAmount
+        ).some)
+      ),
+      TestCase[EntertainmentJourneyAnswers](
+        entertainmentJourneyAnswers,
+        deductions.copy(businessEntertainmentCosts = new DT(
+          None,
+          entertainmentJourneyAnswers.entertainmentAmount.some
+        ).some)
+      ),
+      TestCase[StaffCostsJourneyAnswers](
+        staffCostsJourneyAnswers,
+        deductions.copy(staffCosts = new DT(
+          staffCostsJourneyAnswers.staffCostsAmount.some,
+          staffCostsJourneyAnswers.staffCostsDisallowableAmount
+        ).some)
+      ),
+      TestCase[ConstructionJourneyAnswers](
+        constructionJourneyAnswers,
+        deductions.copy(constructionIndustryScheme = new DT(
+          constructionJourneyAnswers.constructionIndustryAmount.some,
+          constructionJourneyAnswers.constructionIndustryDisallowableAmount
+        ).some)
+      ),
+      TestCase[ProfessionalFeesJourneyAnswers](
+        professionalFeesJourneyAnswers,
+        deductions.copy(professionalFees = SelfEmploymentDeductionsDetailAllowablePosNegType(
+          professionalFeesJourneyAnswers.professionalFeesAmount.some,
+          professionalFeesJourneyAnswers.professionalFeesDisallowableAmount
+        ).some)
+      ),
+      TestCase[InterestJourneyAnswers](
+        interestJourneyAnswers,
+        deductions.copy(interest = new PNT(
+          interestJourneyAnswers.interestAmount.some,
+          interestJourneyAnswers.interestDisallowableAmount
+        ).some)
+      ),
+      TestCase[DepreciationCostsJourneyAnswers](
+        depreciationCostsJourneyAnswers,
+        deductions.copy(depreciation = new PNT(
+          None,
+          depreciationCostsJourneyAnswers.depreciationDisallowableAmount.some
+        ).some)
+      ),
+      TestCase[OtherExpensesJourneyAnswers](
+        otherExpensesJourneyAnswers,
+        deductions.copy(other = new DT(
+          otherExpensesJourneyAnswers.otherExpensesAmount.some,
+          otherExpensesJourneyAnswers.otherExpensesDisallowableAmount
+        ).some)
+      ),
+      TestCase[FinancialChargesJourneyAnswers](
+        financialChargesJourneyAnswers,
+        deductions.copy(financialCharges = new PNT(
+          financialChargesJourneyAnswers.financialChargesAmount.some,
+          financialChargesJourneyAnswers.financialChargesDisallowableAmount
+        ).some)
+      ),
+      TestCase[IrrecoverableDebtsJourneyAnswers](
+        irrecoverableDebtsJourneyAnswers,
+        deductions.copy(badDebt = new PNT(
+          irrecoverableDebtsJourneyAnswers.irrecoverableDebtsAmount.some,
+          irrecoverableDebtsJourneyAnswers.irrecoverableDebtsDisallowableAmount
+        ).some)
+      )
+    )
+
+    "convert from journey to downstream object" in {
+      forAll(cases) { testCase =>
+        assert(testCase.actualDeductions === testCase.expected)
+      }
+    }
+  }
+}

--- a/test/services/journeyAnswers/ExpensesAnswersServiceImplSpec.scala
+++ b/test/services/journeyAnswers/ExpensesAnswersServiceImplSpec.scala
@@ -29,7 +29,7 @@ import models.frontend.expenses.tailoring.ExpensesTailoringAnswers.{AsOneTotalAn
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
-import parsers.expenses.ExpensesResponseParser.goodsToSellOrUseParser
+import models.connector.Api1786ExpensesResponseParser.goodsToSellOrUseParser
 import play.api.libs.json.{JsObject, Json}
 import services.journeyAnswers.ExpensesAnswersServiceImplSpec._
 import stubs.connectors.StubSelfEmploymentConnector

--- a/test/stubs/services/StubExpensesAnswersService.scala
+++ b/test/stubs/services/StubExpensesAnswersService.scala
@@ -18,14 +18,13 @@ package stubs.services
 
 import cats.data.EitherT
 import models.common.{BusinessId, JourneyContextWithNino, Mtditid, TaxYear}
+import models.connector.{Api1786ExpensesResponseParser, Api1894DeductionsBuilder}
 import models.domain.ApiResultT
 import models.error.ServiceError
-import parsers.expenses.ExpensesResponseParser
 import play.api.libs.json.Writes
 import services.journeyAnswers.ExpensesAnswersService
 import stubs.serviceUnitT
 import uk.gov.hmrc.http.HeaderCarrier
-import utils.DeductionsBuilder
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -40,10 +39,10 @@ case class StubExpensesAnswersService(expensesSaveTailoringAnswersRes: ApiResult
   def persistAnswers[A](businessId: BusinessId, taxYear: TaxYear, mtditid: Mtditid, answers: A)(implicit writes: Writes[A]): ApiResultT[Unit] =
     expensesSaveTailoringAnswersRes
 
-  def saveAnswers[A: DeductionsBuilder: Writes](ctx: JourneyContextWithNino, answers: A)(implicit hc: HeaderCarrier): ApiResultT[Unit] =
+  def saveAnswers[A: Api1894DeductionsBuilder: Writes](ctx: JourneyContextWithNino, answers: A)(implicit hc: HeaderCarrier): ApiResultT[Unit] =
     expensesSaveAnswersRes
 
-  def getAnswers[A: ExpensesResponseParser](ctx: JourneyContextWithNino)(implicit hc: HeaderCarrier): ApiResultT[A] =
+  def getAnswers[A: Api1786ExpensesResponseParser](ctx: JourneyContextWithNino)(implicit hc: HeaderCarrier): ApiResultT[A] =
     expensesGetAnswersRes.map(_.asInstanceOf[A])
 
   def getExpensesTailoringAnswers(ctx: JourneyContextWithNino)(implicit hc: HeaderCarrier): ApiResultT[Option[ExpensesTailoringAnswers]] =


### PR DESCRIPTION
Small refactor on top of irrecoverable Debts save:

- I don't like the limit of 30 methods in the class, so I dropped it. It's perfectly fine to have one controller with many "one-liners" methods.
- I added the test for our implicit converts (builder) as I wanted more confidence they work + I moved them to controller model as they are strongly related to specific downstream objects