### PR TITLE
SASS-9589: Fix an empty income page when select NOs

### DIFF
--- a/app/connectors/IFSConnector.scala
+++ b/app/connectors/IFSConnector.scala
@@ -120,9 +120,12 @@ class IFSConnectorImpl @Inject() (http: HttpClient, appConfig: AppConfig) extend
   }
 
   def getAnnualSummaries(ctx: JourneyContextWithNino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Api1803Response] = {
-    val url     = annualSummariesUrl(ctx.nino, ctx.businessId, ctx.taxYear)
-    val context = appConfig.mkMetadata(IFSApiName.Api1803, url)
-    get[Api1803Response](http, context)
+    val url                                                                            = annualSummariesUrl(ctx.nino, ctx.businessId, ctx.taxYear)
+    val context                                                                        = appConfig.mkMetadata(IFSApiName.Api1803, url)
+    implicit val reads: HttpReads[ApiResponse[Option[api_1803.SuccessResponseSchema]]] = commonGetReads[api_1803.SuccessResponseSchema]
+
+    val result = EitherT(get[ApiResponseOption[api_1803.SuccessResponseSchema]](http, context))
+    result.map(_.getOrElse(api_1803.SuccessResponseSchema.empty)).value
   }
 
   def getDisclosuresSubmission(

--- a/app/services/journeyAnswers/NICsAnswersService.scala
+++ b/app/services/journeyAnswers/NICsAnswersService.scala
@@ -20,15 +20,14 @@ import cats.data.EitherT
 import cats.implicits.toFunctorOps
 import connectors.{IFSBusinessDetailsConnector, IFSConnector}
 import models.common._
+import models.connector.api_1171
 import models.connector.api_1638.RequestSchemaAPI1638
 import models.connector.api_1802.request.CreateAmendSEAnnualSubmissionRequestData
-import models.connector.{api_1171, api_1803}
 import models.database.nics.NICsStorageAnswers
 import models.domain.ApiResultT
 import models.error.ServiceError
 import models.error.ServiceError.BusinessNotFoundError
 import models.frontend.nics.{NICsAnswers, NICsClass2Answers, NICsClass4Answers}
-import play.api.http.Status.NOT_FOUND
 import play.api.libs.json.Json
 import repositories.JourneyAnswersRepository
 import uk.gov.hmrc.http.HeaderCarrier

--- a/it/connectors/IFSConnectorImplISpec.scala
+++ b/it/connectors/IFSConnectorImplISpec.scala
@@ -25,12 +25,13 @@ import models.common.TaxYear.{asTys, endDate, startDate}
 import models.connector.api_1638.{RequestSchemaAPI1638, RequestSchemaAPI1638Class2Nics}
 import models.connector.api_1639.{SuccessResponseAPI1639, SuccessResponseAPI1639Class2Nics}
 import models.connector.api_1802.request.{CreateAmendSEAnnualSubmissionRequestBody, CreateAmendSEAnnualSubmissionRequestData}
+import models.connector.api_1803.SuccessResponseSchema
 import models.connector.api_1894.request._
 import models.connector.api_1895.request.{AmendSEPeriodSummaryRequestBody, AmendSEPeriodSummaryRequestData, Incomes}
 import models.connector.api_1965.{ListSEPeriodSummariesResponse, PeriodDetails}
 import org.scalatest.EitherValues._
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
-import play.api.http.Status.{CREATED, OK}
+import play.api.http.Status.{CREATED, NOT_FOUND, OK}
 import play.api.libs.json.Json
 
 class IFSConnectorImplISpec extends WiremockSpec with IntegrationBaseSpec {
@@ -70,6 +71,16 @@ class IFSConnectorImplISpec extends WiremockSpec with IntegrationBaseSpec {
       )
 
       connector.getAnnualSummaries(ctx).futureValue shouldBe successResponse.asRight
+    }
+
+    "return an empty annual summary if not found" in new Api1803Test {
+      stubGetWithResponseBody(
+        url = downstreamUrl,
+        expectedResponse = "{}",
+        expectedStatus = NOT_FOUND
+      )
+
+      connector.getAnnualSummaries(ctx).futureValue shouldBe SuccessResponseSchema(None, None, None).asRight
     }
   }
 


### PR DESCRIPTION
When we answer No to all questions in Income Journey the annual summary resource is not created. Therefore, when we log out and log in again we fetch the data and we need to handle gracefully NOT FOUND error. In this fix I just create an empty object. It seems to fix the issue.