### PR TITLE
ORD-727 - Upgrade to Scala 3.3.5 LTS

### DIFF
--- a/app/connectors/HIP/HipReliefClaimsConnector.scala
+++ b/app/connectors/HIP/HipReliefClaimsConnector.scala
@@ -25,6 +25,7 @@ import models.domain.ApiResultT
 import play.api.Logging
 import play.api.http.Status._
 import play.api.libs.json.Json
+import play.api.libs.ws.WSBodyWritables.writeableOf_JsValue
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, HttpResponse, StringContextOps}
 import utils.IdGenerator

--- a/app/connectors/package.scala
+++ b/app/connectors/package.scala
@@ -16,6 +16,7 @@
 
 import models.connector.IntegrationContext
 import play.api.libs.json.{Json, Writes}
+import play.api.libs.ws.WSBodyWritables.writeableOf_JsValue
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, StringContextOps}
 

--- a/app/models/commonTaskList/TaskListData.scala
+++ b/app/models/commonTaskList/TaskListData.scala
@@ -46,7 +46,7 @@ object TaskListData {
         (__ \ "taxYear").write[Int] and
         (__ \ "data").write[JsObject] and
         (__ \ "lastUpdated").write(MongoJavatimeFormats.instantFormat)
-    )(unlift(TaskListData.unapply))
+    )(td => (td.mtdItId, td.taxYear, td.data, td.lastUpdated))
   }
 
   implicit val format: OFormat[TaskListData] = OFormat(reads, writes)

--- a/app/models/connector/api_1803/AnnualNonFinancialsType.scala
+++ b/app/models/connector/api_1803/AnnualNonFinancialsType.scala
@@ -45,6 +45,6 @@ object AnnualNonFinancialsType {
     val _006 = Value("006")
 
     type Class4NicsExemptionReason = Value
-    implicit lazy val Class4NicsExemptionReasonJsonFormat: Format[Value] = Format(Reads.enumNameReads(this), Writes.enumNameWrites[this.type])
+    implicit lazy val Class4NicsExemptionReasonJsonFormat: Format[Value] = Format(Reads.enumNameReads(this), Writes[Value](v => JsString(v.toString)))
   }
 }

--- a/app/models/connector/businessDetailsConnector/LatencyDetails.scala
+++ b/app/models/connector/businessDetailsConnector/LatencyDetails.scala
@@ -35,7 +35,7 @@ object LatencyDetails {
     val Q = Value("Q")
 
     type LatencyIndicator1 = Value
-    implicit lazy val LatencyIndicator1JsonFormat: Format[Value] = Format(Reads.enumNameReads(this), Writes.enumNameWrites[this.type])
+    implicit lazy val LatencyIndicator1JsonFormat: Format[Value] = Format(Reads.enumNameReads(this), Writes[Value](v => JsString(v.toString)))
   }
 
   // noinspection TypeAnnotation
@@ -44,6 +44,6 @@ object LatencyDetails {
     val Q = Value("Q")
 
     type LatencyIndicator2 = Value
-    implicit lazy val LatencyIndicator2JsonFormat: Format[Value] = Format(Reads.enumNameReads(this), Writes.enumNameWrites[this.type])
+    implicit lazy val LatencyIndicator2JsonFormat: Format[Value] = Format(Reads.enumNameReads(this), Writes[Value](v => JsString(v.toString)))
   }
 }

--- a/app/models/connector/businessDetailsConnector/UkAddressType.scala
+++ b/app/models/connector/businessDetailsConnector/UkAddressType.scala
@@ -49,6 +49,6 @@ object UkAddressType {
     val GB = Value("GB")
 
     type CountryCode = Value
-    implicit lazy val CountryCodeJsonFormat: Format[Value] = Format(Reads.enumNameReads(this), Writes.enumNameWrites[this.type])
+    implicit lazy val CountryCodeJsonFormat: Format[Value] = Format(Reads.enumNameReads(this), Writes[Value](v => JsString(v.toString)))
   }
 }

--- a/app/models/error/ErrorType.scala
+++ b/app/models/error/ErrorType.scala
@@ -38,6 +38,6 @@ object ErrorType {
         case JsString("DOMAIN_ERROR_CODE")     => JsSuccess(DomainErrorCode)
         case jsValue: JsValue                  => JsError(s"ErrorType $jsValue is not one of supported [DOWNSTREAM_ERROR_CODE, DOMAIN_ERROR_CODE]")
       },
-      Writes { errType: ErrorType => JsString(errType.errorCode) }
+      Writes { (errType: ErrorType) => JsString(errType.errorCode) }
     )
 }

--- a/app/models/error/ServiceError.scala
+++ b/app/models/error/ServiceError.scala
@@ -106,7 +106,7 @@ object ServiceError {
             case JsString(s"Mongo exception occurred. Exception: $error") => JsSuccess(MongoError(error))
             case _                                                        => JsError("Invalid format for MongoError")
           },
-          Writes { mge: MongoError =>
+          Writes { (mge: MongoError) =>
             JsString(mge.errorMessage)
           }
         )
@@ -123,7 +123,7 @@ object ServiceError {
               .reads(jsValue)
               .orElse(JsError(s"DataBaseError $jsValue is not one of supported"))
         },
-        Writes { dbError: DatabaseError => JsString(dbError.errorMessage) }
+        Writes { (dbError: DatabaseError) => JsString(dbError.errorMessage) }
       )
 
   }

--- a/app/repositories/MongoJourneyAnswersRepository.scala
+++ b/app/repositories/MongoJourneyAnswersRepository.scala
@@ -70,7 +70,7 @@ class MongoJourneyAnswersRepository @Inject() (mongo: MongoComponent, appConfig:
         IndexModel(
           Indexes.ascending("updatedAt"),
           IndexOptions()
-            .expireAfter(appConfig.mongoTTL, TimeUnit.DAYS)
+            .expireAfter(appConfig.mongoTTL.toLong, TimeUnit.DAYS)
             .name("UserDataTTL")
         ),
         IndexModel(

--- a/app/services/AuditService.scala
+++ b/app/services/AuditService.scala
@@ -48,7 +48,7 @@ class AuditService @Inject() (
         detail = Json.toJson(detail),
         tags = AuditExtensions.auditHeaderCarrier(hc).toAuditDetails()
       )
-    ) map { auditResult: AuditResult =>
+    ) map { (auditResult: AuditResult) =>
       auditResult match {
         case Failure(msg, _) =>
           logger.warn(

--- a/app/services/answers/JourneyAnswerValidationService.scala
+++ b/app/services/answers/JourneyAnswerValidationService.scala
@@ -52,7 +52,7 @@ class JourneyAnswerValidationService @Inject() (implicit ec: ExecutionContext) e
   private def validate[A](json: JsValue)(implicit format: Format[A]): Either[InvalidSection, ValidSection] =
     json.validate[A] match {
       case JsSuccess(value, _) =>
-        val sanitizedJson = removeInvalidFields(Json.toJson(value), getInvalidFields(value))
+        val sanitizedJson = removeInvalidFields(Json.toJson(value)(format), getInvalidFields(value)(format))
         Right(ValidSection(sanitizedJson))
       case JsError(errors) =>
         Left(InvalidSection(errors.map(_._1.toString()).toSeq))

--- a/build.sbt
+++ b/build.sbt
@@ -20,20 +20,19 @@ import uk.gov.hmrc.DefaultBuildSettings
 lazy val appName = "income-tax-self-employment"
 
 ThisBuild / majorVersion := 0
-ThisBuild / scalaVersion := "2.13.18"
+ThisBuild / scalaVersion := "3.3.5"
 
 val additionalScalacOptions = if (sys.props.getOrElse("PLAY_ENV", "") == "CI") Seq("-Xfatal-warnings") else Seq()
 
 lazy val compileOpts = Seq(
   "-feature",
   "-unchecked",
-  "-Ywarn-unused:implicits",
-  "-Ywarn-unused:imports",
-  "-Ywarn-unused:locals",
-  "-Ywarn-unused:params",
-  "-Ywarn-unused:patvars",
-  "-Ywarn-unused:privates",
-  "-Ywarn-value-discard",
+  "-Wunused:implicits",
+  "-Wunused:imports",
+  "-Wunused:locals",
+  "-Wunused:params",
+  "-Wunused:privates",
+  "-Wvalue-discard",
   "-Wconf:src=routes/.*:s"
 ) ++ additionalScalacOptions
 
@@ -53,7 +52,7 @@ lazy val microservice = Project(appName, file("."))
   )
   .settings(CodeCoverageSettings.settings *)
 
-lazy val testSettings: Seq[Def.Setting[_]] = Seq(
+lazy val testSettings: Seq[Def.Setting[?]] = Seq(
   fork := true,
   unmanagedSourceDirectories += baseDirectory.value / "test-utils"
 )

--- a/it/test/connectors/HIP/BroughtForwardLossConnectorISpec.scala
+++ b/it/test/connectors/HIP/BroughtForwardLossConnectorISpec.scala
@@ -20,7 +20,6 @@ import base.IntegrationBaseSpec
 import connectors.data._
 import models.common.JourneyContextWithNino
 import models.error.DownstreamError.GenericDownstreamError
-import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import play.api.http.Status._
 import play.api.test.Helpers.await
 
@@ -36,7 +35,7 @@ class BroughtForwardLossConnectorISpec extends IntegrationBaseSpec {
         expectedResponse = "",
         expectedStatus = NO_CONTENT
       )
-      await(connector.deleteBroughtForwardLoss(testNino, testTaxYear, testBusinessId.value).value) shouldBe Right(())
+      await(connector.deleteBroughtForwardLoss(testNino, testTaxYear, testBusinessId.value).value) mustBe Right(())
     }
 
     Seq(
@@ -53,7 +52,7 @@ class BroughtForwardLossConnectorISpec extends IntegrationBaseSpec {
           expectedResponse = "",
           expectedStatus = status
         )
-        await(connector.deleteBroughtForwardLoss(testNino, testTaxYear, testBusinessId.value).value) shouldBe Left(
+        await(connector.deleteBroughtForwardLoss(testNino, testTaxYear, testBusinessId.value).value) mustBe Left(
           GenericDownstreamError(
             status,
             s"Downstream error when calling DELETE http://localhost:11111$deleteBroughtForwardLossDownstreamUrl: status=$status, body:\n"))

--- a/it/test/connectors/HIP/IncomeSourceConnectorISpec.scala
+++ b/it/test/connectors/HIP/IncomeSourceConnectorISpec.scala
@@ -19,7 +19,7 @@ package connectors.HIP
 import base.IntegrationBaseSpec
 import models.connector.api_2085.ListOfIncomeSources
 import models.error.DownstreamError
-import org.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.http.Status._
 import play.api.libs.json.Json
 import play.api.test.Helpers.await

--- a/it/test/connectors/IFS/IFSBusinessDetailsConnectorImplISpec.scala
+++ b/it/test/connectors/IFS/IFSBusinessDetailsConnectorImplISpec.scala
@@ -23,7 +23,6 @@ import models.common.JourneyContextWithNino
 import models.connector.api_2085.ListOfIncomeSources
 import models.error.DownstreamError.GenericDownstreamError
 import models.error.ServiceError
-import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import play.api.http.Status._
 import play.api.test.Helpers.await
 
@@ -40,7 +39,7 @@ class IFSBusinessDetailsConnectorImplISpec extends IntegrationBaseSpec {
 //        expectedResponse = api1171IfsResponseJson,
 //        expectedStatus = OK
 //      )
-//      connector.getBusinesses(testNino).value.futureValue shouldBe Right(api1171IfsResponse)
+//      connector.getBusinesses(testNino).value.futureValue mustBe Right(api1171IfsResponse)
     }
   }
 
@@ -51,7 +50,7 @@ class IFSBusinessDetailsConnectorImplISpec extends IntegrationBaseSpec {
         expectedResponse = api1871ResponseJson,
         expectedStatus = OK
       )
-      await(connector.getBusinessIncomeSourcesSummary(testTaxYear, testNino, testBusinessId).value) shouldBe Right(api1871Response)
+      await(connector.getBusinessIncomeSourcesSummary(testTaxYear, testNino, testBusinessId).value) mustBe Right(api1871Response)
     }
   }
 
@@ -63,7 +62,7 @@ class IFSBusinessDetailsConnectorImplISpec extends IntegrationBaseSpec {
         expectedResponse = api1500ResponseJson,
         expectedStatus = OK
       )
-      await(connector.createBroughtForwardLoss(data).value) shouldBe api1500Response.asRight
+      await(connector.createBroughtForwardLoss(data).value) mustBe api1500Response.asRight
     }
   }
 
@@ -75,7 +74,7 @@ class IFSBusinessDetailsConnectorImplISpec extends IntegrationBaseSpec {
         expectedResponse = api1501ResponseJson,
         expectedStatus = OK
       )
-      await(connector.updateBroughtForwardLoss(data).value) shouldBe api1501Response.asRight
+      await(connector.updateBroughtForwardLoss(data).value) mustBe api1501Response.asRight
     }
   }
 
@@ -86,7 +85,7 @@ class IFSBusinessDetailsConnectorImplISpec extends IntegrationBaseSpec {
         expectedResponse = api1502ResponseJson,
         expectedStatus = OK
       )
-      await(connector.getBroughtForwardLoss(testNino, testBusinessId.value).value) shouldBe api1502Response.asRight
+      await(connector.getBroughtForwardLoss(testNino, testBusinessId.value).value) mustBe api1502Response.asRight
     }
   }
 
@@ -97,7 +96,7 @@ class IFSBusinessDetailsConnectorImplISpec extends IntegrationBaseSpec {
         expectedResponse = api1870ResponseJson,
         expectedStatus = OK
       )
-      await(connector.listBroughtForwardLosses(testNino, testTaxYear).value) shouldBe api1870Response.asRight
+      await(connector.listBroughtForwardLosses(testNino, testTaxYear).value) mustBe api1870Response.asRight
     }
   }
 
@@ -109,7 +108,7 @@ class IFSBusinessDetailsConnectorImplISpec extends IntegrationBaseSpec {
         expectedStatus = OK
       )
 
-      await(connector.getListOfIncomeSources(testTaxYear, testNino).value) shouldBe api2085Response.asRight
+      await(connector.getListOfIncomeSources(testTaxYear, testNino).value) mustBe api2085Response.asRight
     }
 
     for (errorStatus <- Seq(BAD_REQUEST, NOT_FOUND, SERVICE_UNAVAILABLE, INTERNAL_SERVER_ERROR))
@@ -123,11 +122,11 @@ class IFSBusinessDetailsConnectorImplISpec extends IntegrationBaseSpec {
         val result: Either[ServiceError, ListOfIncomeSources] = await(connector.getListOfIncomeSources(testTaxYear, testNino).value)
         result match {
           case Left(GenericDownstreamError(status, message)) =>
-            status shouldBe errorStatus
-            message should include(
+            status mustBe errorStatus
+            message must include(
               s"Downstream error when calling GET http://localhost:11111/income-tax/income-sources/$testNino?taxYear=${testTaxYear.toYYYY_YY}")
-            message should include(s"status=$errorStatus")
-            message should include(s"body:\n$api2085FailedResponse")
+            message must include(s"status=$errorStatus")
+            message must include(s"body:\n$api2085FailedResponse")
           case _ => fail("Expected a GenericDownstreamError")
         }
       }

--- a/it/test/connectors/IFS/IFSConnectorImplISpec.scala
+++ b/it/test/connectors/IFS/IFSConnectorImplISpec.scala
@@ -33,7 +33,6 @@ import models.error.DownstreamErrorBody.SingleDownstreamErrorBody
 import models.error.ErrorType.DownstreamErrorCode
 import models.error.ServiceError
 import org.scalatest.EitherValues._
-import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import play.api.http.Status._
 import play.api.libs.json.Json
 import play.api.test.Helpers.await
@@ -50,7 +49,7 @@ class IFSConnectorImplISpec extends IntegrationBaseSpec {
         expectedResponse = api1786ResponseJson,
         expectedStatus = OK
       )
-      await(connector.getPeriodicSummaryDetail(ctx)) shouldBe api1786Response.asRight
+      await(connector.getPeriodicSummaryDetail(ctx)) mustBe api1786Response.asRight
     }
   }
 
@@ -62,7 +61,7 @@ class IFSConnectorImplISpec extends IntegrationBaseSpec {
         expectedResponse = downstreamSuccessResponse,
         expectedStatus = OK)
 
-      await(connector.createAmendSEAnnualSubmission(data)) shouldBe ().asRight
+      await(connector.createAmendSEAnnualSubmission(data)) mustBe ().asRight
     }
   }
 
@@ -74,7 +73,7 @@ class IFSConnectorImplISpec extends IntegrationBaseSpec {
         expectedStatus = OK
       )
 
-      await(connector.getAnnualSummaries(ctx)) shouldBe api1171Response.asRight
+      await(connector.getAnnualSummaries(ctx)) mustBe api1171Response.asRight
     }
 
     "return an empty annual summary if not found" in new Api1803Test {
@@ -84,7 +83,7 @@ class IFSConnectorImplISpec extends IntegrationBaseSpec {
         expectedStatus = NOT_FOUND
       )
 
-      await(connector.getAnnualSummaries(ctx)) shouldBe SuccessResponseSchema(None, None, None).asRight
+      await(connector.getAnnualSummaries(ctx)) mustBe SuccessResponseSchema(None, None, None).asRight
     }
   }
 
@@ -109,7 +108,7 @@ class IFSConnectorImplISpec extends IntegrationBaseSpec {
         expectedStatus = OK
       )
 
-      await(connector.createUpdateOrDeleteApiAnnualSummaries(ctx, None).value) shouldBe ().asRight
+      await(connector.createUpdateOrDeleteApiAnnualSummaries(ctx, None).value) mustBe ().asRight
     }
     "send a DELETE request when given no data to submit" in new Api1802Test {
       stubPutWithRequestAndResponseBody(
@@ -118,7 +117,7 @@ class IFSConnectorImplISpec extends IntegrationBaseSpec {
         expectedResponse = downstreamSuccessResponse,
         expectedStatus = OK)
 
-      await(connector.createUpdateOrDeleteApiAnnualSummaries(ctx, requestBody.some).value) shouldBe ().asRight
+      await(connector.createUpdateOrDeleteApiAnnualSummaries(ctx, requestBody.some).value) mustBe ().asRight
     }
   }
 
@@ -130,7 +129,7 @@ class IFSConnectorImplISpec extends IntegrationBaseSpec {
         expectedResponse = downstreamSuccessResponse,
         expectedStatus = CREATED)
 
-      await(connector.createSEPeriodSummary(data)) shouldBe ().asRight
+      await(connector.createSEPeriodSummary(data)) mustBe ().asRight
     }
   }
 
@@ -142,7 +141,7 @@ class IFSConnectorImplISpec extends IntegrationBaseSpec {
         expectedResponse = downstreamSuccessResponse,
         expectedStatus = OK)
 
-      await(connector.amendSEPeriodSummary(data)) shouldBe ().asRight
+      await(connector.amendSEPeriodSummary(data)) mustBe ().asRight
     }
   }
 
@@ -157,7 +156,7 @@ class IFSConnectorImplISpec extends IntegrationBaseSpec {
       val expectedResponse: Option[ListSEPeriodSummariesResponse] =
         Option(ListSEPeriodSummariesResponse(Some(List(PeriodDetails(None, Some("2023-04-06"), Some("2024-04-05"))))))
 
-      await(connector.listSEPeriodSummary(ctx)) shouldBe expectedResponse.asRight
+      await(connector.listSEPeriodSummary(ctx)) mustBe expectedResponse.asRight
     }
   }
 
@@ -208,7 +207,7 @@ class IFSConnectorImplISpec extends IntegrationBaseSpec {
     "return a success" in new Api1505Test {
       stubPostWithRequestAndResponseBody(url = downstreamUrl, requestBody = requestBody, expectedResponse = api1171ResponseJson, expectedStatus = OK)
 
-      await(connector.createLossClaim(ctx, requestBody).value) shouldBe api1171Response.asRight
+      await(connector.createLossClaim(ctx, requestBody).value) mustBe api1171Response.asRight
     }
 
     "return a ParsingError when expectedResponse is incorrect" in new Api1505Test {
@@ -218,7 +217,7 @@ class IFSConnectorImplISpec extends IntegrationBaseSpec {
         expectedResponse = badRequestResponseRaw,
         expectedStatus = OK)
 
-      await(connector.createLossClaim(ctx, requestBody).value) shouldBe
+      await(connector.createLossClaim(ctx, requestBody).value) mustBe
         Left(SingleDownstreamError(500, SingleDownstreamErrorBody("PARSING_ERROR", "Error parsing response from API", DownstreamErrorCode)))
     }
 
@@ -233,10 +232,10 @@ class IFSConnectorImplISpec extends IntegrationBaseSpec {
       val result: Either[ServiceError, ClaimId] = await(connector.createLossClaim(ctx, requestBody).value)
       result match {
         case Left(GenericDownstreamError(status, message)) =>
-          status shouldBe 400
-          message should include(s"Downstream error when calling POST http://localhost:11111$downstreamUrl")
-          message should include(s"status=$BAD_REQUEST")
-          message should include(s"body:\n$api1171ResponseJson")
+          status mustBe 400
+          message must include(s"Downstream error when calling POST http://localhost:11111$downstreamUrl")
+          message must include(s"status=$BAD_REQUEST")
+          message must include(s"body:\n$api1171ResponseJson")
         case _ => fail("Expected a GenericDownstreamError")
       }
     }
@@ -252,10 +251,10 @@ class IFSConnectorImplISpec extends IntegrationBaseSpec {
       val result: Either[ServiceError, ClaimId] = await(connector.createLossClaim(ctx, requestBody).value)
       result match {
         case Left(GenericDownstreamError(status, message)) =>
-          status shouldBe 404
-          message should include(s"Downstream error when calling POST http://localhost:11111$downstreamUrl")
-          message should include(s"status=$NOT_FOUND")
-          message should include(s"body:\n$api1171ResponseJson")
+          status mustBe 404
+          message must include(s"Downstream error when calling POST http://localhost:11111$downstreamUrl")
+          message must include(s"status=$NOT_FOUND")
+          message must include(s"body:\n$api1171ResponseJson")
         case _ => fail("Expected a GenericDownstreamError")
       }
     }
@@ -271,10 +270,10 @@ class IFSConnectorImplISpec extends IntegrationBaseSpec {
       val result: Either[ServiceError, ClaimId] = await(connector.createLossClaim(ctx, requestBody).value)
       result match {
         case Left(GenericDownstreamError(status, message)) =>
-          status shouldBe 409
-          message should include(s"Downstream error when calling POST http://localhost:11111$downstreamUrl")
-          message should include(s"status=$CONFLICT")
-          message should include(s"body:\n$api1171ResponseJson")
+          status mustBe 409
+          message must include(s"Downstream error when calling POST http://localhost:11111$downstreamUrl")
+          message must include(s"status=$CONFLICT")
+          message must include(s"body:\n$api1171ResponseJson")
         case _ => fail("Expected a GenericDownstreamError")
       }
     }
@@ -290,10 +289,10 @@ class IFSConnectorImplISpec extends IntegrationBaseSpec {
       val result: Either[ServiceError, ClaimId] = await(connector.createLossClaim(ctx, requestBody).value)
       result match {
         case Left(GenericDownstreamError(status, message)) =>
-          status shouldBe 422
-          message should include(s"Downstream error when calling POST http://localhost:11111$downstreamUrl")
-          message should include(s"status=$UNPROCESSABLE_ENTITY")
-          message should include(s"body:\n$api1171ResponseJson")
+          status mustBe 422
+          message must include(s"Downstream error when calling POST http://localhost:11111$downstreamUrl")
+          message must include(s"status=$UNPROCESSABLE_ENTITY")
+          message must include(s"body:\n$api1171ResponseJson")
         case _ => fail("Expected a GenericDownstreamError")
       }
     }
@@ -310,10 +309,10 @@ class IFSConnectorImplISpec extends IntegrationBaseSpec {
 
       result match {
         case Left(GenericDownstreamError(status, message)) =>
-          status shouldBe 201
-          message should include(s"Downstream error when calling POST http://localhost:11111$downstreamUrl")
-          message should include(s"status=$CREATED")
-          message should include(s"body:\n${api1171Response.claimId}")
+          status mustBe 201
+          message must include(s"Downstream error when calling POST http://localhost:11111$downstreamUrl")
+          message must include(s"status=$CREATED")
+          message must include(s"body:\n${api1171Response.claimId}")
         case _ => fail("Expected a GenericDownstreamError")
       }
     }

--- a/it/test/connectors/MDTP/MDTPConnectorImplISpec.scala
+++ b/it/test/connectors/MDTP/MDTPConnectorImplISpec.scala
@@ -19,7 +19,6 @@ package connectors.MDTP
 import base.IntegrationBaseSpec
 import cats.implicits.catsSyntaxEitherId
 import connectors.data.CitizenDetailsTest
-import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import play.api.http.Status.OK
 import play.api.test.Helpers.await
 
@@ -33,7 +32,7 @@ class MDTPConnectorImplISpec extends IntegrationBaseSpec {
         expectedResponse = api1171ResponseJson,
         expectedStatus = OK
       )
-      await(connector.getCitizenDetails(testNino).value) shouldBe api1171Response.asRight
+      await(connector.getCitizenDetails(testNino).value) mustBe api1171Response.asRight
     }
   }
 

--- a/it/test/controllers/BusinessDetailsControllerISpec.scala
+++ b/it/test/controllers/BusinessDetailsControllerISpec.scala
@@ -22,6 +22,7 @@ import helpers.AuthStub
 import models.common.{BusinessId, Nino}
 import play.api.http.Status.{NOT_FOUND, OK}
 import play.api.libs.json.Json
+import play.api.libs.ws.DefaultBodyReadables.readableAsString
 import play.api.test.Helpers.await
 
 class BusinessDetailsControllerISpec extends IntegrationBaseSpec with AuthStub with Api1171Test {

--- a/it/test/controllers/JourneyAnswersControllerISpec.scala
+++ b/it/test/controllers/JourneyAnswersControllerISpec.scala
@@ -21,6 +21,8 @@ import models.connector.api_1803.{AnnualAllowancesType, SuccessResponseSchema}
 import models.frontend.adjustments.{ProfitOrLossJourneyAnswers, WhichYearIsLossReported}
 import play.api.http.Status.NO_CONTENT
 import play.api.libs.json.{JsValue, Json}
+import play.api.libs.ws.DefaultBodyWritables._
+import play.api.libs.ws.JsonBodyWritables._
 
 class JourneyAnswersControllerISpec extends IntegrationBaseSpec {
 

--- a/it/test/controllers/TravelExpensesControllerISpec.scala
+++ b/it/test/controllers/TravelExpensesControllerISpec.scala
@@ -24,8 +24,9 @@ import models.common.{BusinessId, Nino, TaxYear}
 import play.api.http.Status.{BAD_REQUEST, NOT_FOUND, NO_CONTENT, OK}
 import play.api.libs.json.Json
 import play.api.libs.ws.WSResponse
+import play.api.libs.ws.DefaultBodyWritables._
+import play.api.libs.ws.JsonBodyWritables._
 import play.api.test.Helpers.await
-
 
 class TravelExpensesControllerISpec extends IntegrationBaseSpec with AuthStub {
 

--- a/it/test/controllers/answers/AnswerControllerISpec.scala
+++ b/it/test/controllers/answers/AnswerControllerISpec.scala
@@ -22,6 +22,8 @@ import models.common.JourneyName.TravelExpenses
 import play.api.http.Status._
 import play.api.libs.json.Json
 import play.api.libs.ws.WSResponse
+import play.api.libs.ws.DefaultBodyWritables._
+import play.api.libs.ws.JsonBodyWritables._
 import play.api.test.Helpers.await
 import testdata.AnswerApiTestData
 

--- a/it/test/controllers/answers/CollectionAnswerControllerISpec.scala
+++ b/it/test/controllers/answers/CollectionAnswerControllerISpec.scala
@@ -23,6 +23,8 @@ import models.database.expenses.travel._
 import play.api.http.Status._
 import play.api.libs.json.Json
 import play.api.libs.ws.WSResponse
+import play.api.libs.ws.DefaultBodyWritables._
+import play.api.libs.ws.JsonBodyWritables._
 import play.api.test.Helpers.await
 import services.answers.CollectionSection
 

--- a/it/test/helpers/JourneyAnswersHelper.scala
+++ b/it/test/helpers/JourneyAnswersHelper.scala
@@ -20,6 +20,7 @@ import models.common.JourneyName
 import models.common.JourneyName.TravelExpenses
 import models.common.JourneyStatus.InProgress
 import models.database.JourneyAnswers
+import org.mongodb.scala._
 import org.mongodb.scala.bson.conversions.Bson
 import org.mongodb.scala.model.Filters
 import org.mongodb.scala.result.DeleteResult

--- a/it/test/models/frontend/adjustments/WhichYearIsLossReportedSpec.scala
+++ b/it/test/models/frontend/adjustments/WhichYearIsLossReportedSpec.scala
@@ -18,9 +18,9 @@ package models.frontend.adjustments
 
 import models.frontend.adjustments.WhichYearIsLossReported.{Year2018to2019, Year2019to2020, Year2020to2021, Year2021to2022, Year2022to2023}
 import org.scalatest.freespec.AnyFreeSpec
-import utils.TestUtils.convertToAnyMustWrapper
+import org.scalatest.matchers.must.Matchers
 
-class WhichYearIsLossReportedSpec extends AnyFreeSpec {
+class WhichYearIsLossReportedSpec extends AnyFreeSpec with Matchers {
 
   "WhichYearIsLossReported" - {
     "convert to WhichYearIsLossReported for the valid input" in {

--- a/it/test/repositories/MongoJourneyAnswersRepositoryISpec.scala
+++ b/it/test/repositories/MongoJourneyAnswersRepositoryISpec.scala
@@ -28,7 +28,7 @@ import models.database.expenses.travel.TravelExpensesDb
 import models.domain.{JourneyNameAndStatus, TradesJourneyStatuses}
 import models.error.ServiceError
 import models.frontend.TaskList
-import org.mockito.MockitoSugar.{reset, when}
+import org.mockito.Mockito.{reset, when}
 import org.scalatest.EitherValues._
 import org.scalatestplus.mockito.MockitoSugar.mock
 import play.api.libs.json.{JsObject, Json}
@@ -49,7 +49,7 @@ class MongoJourneyAnswersRepositoryISpec extends MongoSpec with MongoTestSupport
 
   private val TTLinSeconds = mockAppConfig.mongoTTL * 3600 * 24
 
-  override val repository                           = new MongoJourneyAnswersRepository(mongoComponent, mockAppConfig, mockClock)
+  override val repository: MongoJourneyAnswersRepository = new MongoJourneyAnswersRepository(mongoComponent, mockAppConfig, mockClock)
   override val mongo: MongoJourneyAnswersRepository = repository // Required by JourneyAnswersHelper
 
   override def beforeEach(): Unit = {

--- a/it/test/repositories/package.scala
+++ b/it/test/repositories/package.scala
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import org.mongodb.scala._
 import org.mongodb.scala.MongoCollection
 import org.mongodb.scala.model.Filters
 

--- a/it/test/utils/MockIdGenerator.scala
+++ b/it/test/utils/MockIdGenerator.scala
@@ -16,8 +16,8 @@
 
 package utils
 
-import org.mockito.MockitoSugar.when
-import org.mockito.stubbing.ScalaOngoingStubbing
+import org.mockito.Mockito.when
+import org.mockito.stubbing.OngoingStubbing as ScalaOngoingStubbing
 import org.scalatestplus.mockito.MockitoSugar.mock
 
 trait MockIdGenerator {

--- a/it/test/utils/MockTimeMachine.scala
+++ b/it/test/utils/MockTimeMachine.scala
@@ -16,8 +16,9 @@
 
 package utils
 
-import org.mockito.MockitoSugar
-import org.mockito.stubbing.ScalaOngoingStubbing
+import org.mockito.Mockito.when
+import org.mockito.stubbing.OngoingStubbing as ScalaOngoingStubbing
+import org.scalatestplus.mockito.MockitoSugar
 
 import java.time.temporal.ChronoUnit
 import java.time.{OffsetDateTime, ZonedDateTime}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -47,10 +47,10 @@ object AppDependencies {
     "org.playframework"      %% "play-test"                % current,
     "org.scalatest"          %% "scalatest"                % "3.2.19",
     "org.scalatestplus"      %% "scalacheck-1-15"          % "3.2.11.0",
-    "org.mockito"            %% "mockito-scala-scalatest"  % "2.1.0",
     "org.typelevel"          %% "cats-core"                % "2.13.0",
     "com.vladsch.flexmark"    % "flexmark-all"             % "0.64.8",
     "org.scalatestplus.play" %% "scalatestplus-play"       % "7.0.2",
+    "org.mockito"            %% "mockito-scala-scalatest"  % "2.2.1",
     "com.github.tomakehurst"  % "wiremock-jre8-standalone" % "3.0.1",
     "org.scalamock"          %% "scalamock"                % "7.5.5"
   ).map(_ % Test)

--- a/project/CodeCoverageSettings.scala
+++ b/project/CodeCoverageSettings.scala
@@ -32,7 +32,7 @@ object CodeCoverageSettings {
     "controllers.testonly.*"
   )
 
-  val settings: Seq[Setting[_]] = Seq(
+  val settings: Seq[Setting[?]] = Seq(
     ScoverageKeys.coverageExcludedPackages   := excludedPackages.mkString(";"),
     ScoverageKeys.coverageMinimumStmtTotal   := 85.62,
     ScoverageKeys.coverageMinimumBranchTotal := 73.17,

--- a/test/controllers/JourneyAnswersControllerSpec.scala
+++ b/test/controllers/JourneyAnswersControllerSpec.scala
@@ -34,6 +34,7 @@ import mocks.services.{MockExpensesAnswersService, MockPeriodSummaryService}
 import models.common.JourneyName
 import models.error.DownstreamError.SingleDownstreamError
 import models.error.DownstreamErrorBody.SingleDownstreamErrorBody
+import models.error.ServiceError
 import models.frontend.capitalAllowances.annualInvestmentAllowance.AnnualInvestmentAllowanceAnswers
 import models.frontend.capitalAllowances.balancingAllowance.BalancingAllowanceAnswers
 import models.frontend.capitalAllowances.balancingCharge.BalancingChargeAnswers
@@ -68,9 +69,10 @@ import play.api.libs.json.{Json, Writes}
 import play.api.mvc.{Action, AnyContent}
 import services.journeyAnswers.CapitalAllowancesAnswersService
 import services.journeyAnswers.expenses.{ExpensesAnswersService, PeriodSummaryService}
-import stubs.serviceErrorT
 import stubs.services._
 import utils.BaseSpec._
+
+import scala.concurrent.Future
 
 
 class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckPropertyChecks with TableDrivenPropertyChecks with OptionValues {
@@ -272,7 +274,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
         auth = mockAuthorisedAction,
         cc = stubControllerComponents,
         abroadAnswersService = StubAbroadAnswersService(),
-        incomeService = StubIncomeAnswersService(incomeJourneyAnswersRes = EitherT.leftT(downstreamError)),
+        incomeService = StubIncomeAnswersService(incomeJourneyAnswersRes = EitherT.left[Unit](Future.successful(downstreamError: ServiceError))),
         periodSummaryService = mockPeriodSummaryService,
         expensesService = mockExpensesAnswersService,
         capitalAllowancesService = StubCapitalAllowancesAnswersAnswersService(),
@@ -336,7 +338,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
 
     "Get return correct status if for get tailoring answers" in
       forAll(cases) { (journeyAnswers, expectedStatus) =>
-        MockExpensesAnswersService.getExpensesTailoringAnswers(journeyCtxWithNino)(EitherT.rightT(journeyAnswers))
+        MockExpensesAnswersService.getExpensesTailoringAnswers(journeyCtxWithNino)(EitherT.right[ServiceError](Future.successful(journeyAnswers)))
 
         val controller: JourneyAnswersController = new JourneyAnswersController(
           auth = mockAuthorisedAction,
@@ -360,14 +362,14 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     }
 
     s"Save ExpensesTailoringNoExpenses return a $NO_CONTENT when successful" in {
-      MockExpensesAnswersService.saveTailoringAnswers(journeyCtxWithNino, NoExpensesAnswers)(EitherT.rightT(()))
+      MockExpensesAnswersService.saveTailoringAnswers(journeyCtxWithNino, NoExpensesAnswers)(EitherT.right[ServiceError](Future.successful(())))
 
       checkNoContent(underTest.saveExpensesTailoringNoExpenses(currTaxYear, businessId, nino))
     }
 
     s"Save ExpensesTailoringIndividualCategories return a $NO_CONTENT when successful" in {
       forAll(expensesTailoringIndividualCategoriesAnswersGen) { data =>
-        MockExpensesAnswersService.saveTailoringAnswers(journeyCtxWithNino, data)(EitherT.rightT(()))
+        MockExpensesAnswersService.saveTailoringAnswers(journeyCtxWithNino, data)(EitherT.right[ServiceError](Future.successful(())))
 
         behave like testRoute(
           request = buildRequest(data),
@@ -380,7 +382,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
 
     s"Save ExpensesTailoringTotalAmount return a $NO_CONTENT when successful" in {
       forAll(expensesTailoringTotalAmountAnswersGen) { data =>
-        MockExpensesAnswersService.saveTailoringAnswers(journeyCtxWithNino, data)(EitherT.rightT(()))
+        MockExpensesAnswersService.saveTailoringAnswers(journeyCtxWithNino, data)(EitherT.right[ServiceError](Future.successful(())))
 
         behave like testRoute(
           request = buildRequest(data),
@@ -392,7 +394,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     }
 
   "clearExpensesSimplifiedOrNoExpensesAnswers" in {
-    MockExpensesAnswersService.deleteSimplifiedExpensesAnswers(journeyCtxWithNino)(EitherT.rightT(()))
+    MockExpensesAnswersService.deleteSimplifiedExpensesAnswers(journeyCtxWithNino)(EitherT.right[ServiceError](Future.successful(())))
 
     behave like testRoute(
       request = buildRequestNoContent,
@@ -403,7 +405,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
   }
 
   s"clearExpensesAndCapitalAllowancesData" in {
-    MockExpensesAnswersService.clearExpensesAndCapitalAllowancesData(journeyCtxWithNino)(EitherT.rightT(()))
+    MockExpensesAnswersService.clearExpensesAndCapitalAllowancesData(journeyCtxWithNino)(EitherT.right[ServiceError](Future.successful(())))
 
     behave like testRoute(
       request = buildRequestNoContent,
@@ -414,7 +416,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
   }
 
   s"clearOfficeSuppliesExpensesData" in {
-    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.OfficeSupplies)(EitherT.rightT(()))
+    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.OfficeSupplies)(EitherT.right[ServiceError](Future.successful(())))
 
     behave like testRoute(
       request = buildRequestNoContent,
@@ -425,7 +427,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
   }
 
   s"clearGoodsToSellOrUseExpensesData" in {
-    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.GoodsToSellOrUse)(EitherT.rightT(()))
+    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.GoodsToSellOrUse)(EitherT.right[ServiceError](Future.successful(())))
 
     behave like testRoute(
       request = buildRequestNoContent,
@@ -436,7 +438,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
   }
 
   "clearRepairsAndMaintenanceExpensesData" in {
-    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.RepairsAndMaintenanceCosts)(EitherT.rightT(()))
+    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.RepairsAndMaintenanceCosts)(EitherT.right[ServiceError](Future.successful(())))
 
     behave like testRoute(
       request = buildRequestNoContent,
@@ -447,7 +449,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
   }
 
   "clearStaffCostsExpensesData" in {
-    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.StaffCosts)(EitherT.rightT(()))
+    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.StaffCosts)(EitherT.right[ServiceError](Future.successful(())))
 
     behave like testRoute(
       request = buildRequestNoContent,
@@ -458,7 +460,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
   }
 
   "clearWorkplaceRunningCostsExpensesData" in {
-    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.WorkplaceRunningCosts)(EitherT.rightT(()))
+    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.WorkplaceRunningCosts)(EitherT.right[ServiceError](Future.successful(())))
 
     behave like testRoute(
       request = buildRequestNoContent,
@@ -469,7 +471,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
   }
 
   "clearConstructionExpensesData" in {
-    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.Construction)(EitherT.rightT(()))
+    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.Construction)(EitherT.right[ServiceError](Future.successful(())))
 
     behave like testRoute(
       request = buildRequestNoContent,
@@ -480,7 +482,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
   }
 
   "clearProfessionalFeesExpensesData" in {
-    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.ProfessionalFees)(EitherT.rightT(()))
+    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.ProfessionalFees)(EitherT.right[ServiceError](Future.successful(())))
 
     behave like testRoute(
       request = buildRequestNoContent,
@@ -491,29 +493,18 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
   }
 
   "clearOtherExpensesExpensesData" in {
-    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.ProfessionalFees)(serviceErrorT)
+    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.OtherExpenses)(EitherT.right[ServiceError](Future.successful(())))
 
     behave like testRoute(
       request = buildRequestNoContent,
       expectedStatus = NO_CONTENT,
       expectedBody = "",
-      methodBlock = () => underTest.clearProfessionalFeesExpensesData(currTaxYear, businessId, nino)
+      methodBlock = () => underTest.clearOtherExpensesData(currTaxYear, businessId, nino)
     )
-
-    (BAD_REQUEST, INTERNAL_SERVER_ERROR) map { status =>
-      behave like testRoute(
-        request = buildRequestNoContent,
-        expectedStatus = status,
-        expectedBody = "",
-        methodBlock = () => {
-          underTest.clearOtherExpensesData(currTaxYear, businessId, nino)
-        }
-      )
-    }
   }
 
   "clearFinancialChargeExpensesData" in {
-    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.FinancialCharges)(serviceErrorT)
+    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.FinancialCharges)(EitherT.right[ServiceError](Future.successful(())))
 
     behave like testRoute(
       request = buildRequestNoContent,
@@ -521,21 +512,10 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
       expectedBody = "",
       methodBlock = () => underTest.clearFinancialChargeExpensesData(currTaxYear, businessId, nino)
     )
-
-    (BAD_REQUEST, INTERNAL_SERVER_ERROR) map { status =>
-      behave like testRoute(
-        request = buildRequestNoContent,
-        expectedStatus = status,
-        expectedBody = "",
-        methodBlock = () => {
-          underTest.clearOtherExpensesData(currTaxYear, businessId, nino)
-        }
-      )
-    }
   }
 
   "clearInterestOnBankAndOtherExpensesData" in {
-    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.Interest)(serviceErrorT)
+    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.Interest)(EitherT.right[ServiceError](Future.successful(())))
 
     behave like testRoute(
       request = buildRequestNoContent,
@@ -543,21 +523,10 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
       expectedBody = "",
       methodBlock = () => underTest.clearInterestOnBankAndOtherExpensesData(currTaxYear, businessId, nino)
     )
-
-    (BAD_REQUEST, INTERNAL_SERVER_ERROR) map { status =>
-      behave like testRoute(
-        request = buildRequestNoContent,
-        expectedStatus = status,
-        expectedBody = "",
-        methodBlock = () => {
-          underTest.clearOtherExpensesData(currTaxYear, businessId, nino)
-        }
-      )
-    }
   }
 
   "clearAdvertisingOrMarketingExpensesData" in {
-    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.AdvertisingOrMarketing)(EitherT.rightT(()))
+    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.AdvertisingOrMarketing)(EitherT.right[ServiceError](Future.successful(())))
 
     behave like testRoute(
       request = buildRequestNoContent,
@@ -569,7 +538,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
   }
 
   "clearIrrecoverableDebtsExpensesData" in {
-    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.IrrecoverableDebts)(EitherT.rightT(()))
+    MockExpensesAnswersService.clearExpensesData(journeyCtxWithNino, JourneyName.IrrecoverableDebts)(EitherT.right[ServiceError](Future.successful(())))
 
     behave like testRoute(
       request = buildRequestNoContent,
@@ -581,14 +550,14 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
 
   "GoodsToSellOrUse" should {
     s"Get return $NO_CONTENT if there is no answers" in {
-      MockExpensesAnswersService.getGoodsToSellOrUseAnswers(journeyCtxWithNino)(EitherT.rightT(None))
+      MockExpensesAnswersService.getGoodsToSellOrUseAnswers(journeyCtxWithNino)(EitherT.right[ServiceError](Future.successful(None)))
 
       checkNoContent(underTest.getGoodsToSellOrUse(currTaxYear, businessId, nino))
     }
 
     s"Get answers and return a $OK when successful" in new GetExpensesTest[GoodsToSellOrUseAnswers] {
       override val journeyAnswers: GoodsToSellOrUseAnswers = genOne(goodsToSellOrUseAnswersGen)
-      MockExpensesAnswersService.getGoodsToSellOrUseAnswers(journeyCtxWithNino)(EitherT.rightT(Some(journeyAnswers)))
+      MockExpensesAnswersService.getGoodsToSellOrUseAnswers(journeyCtxWithNino)(EitherT.right[ServiceError](Future.successful(Some(journeyAnswers))))
 
       behave like testRoute(
         request = buildRequestNoContent,
@@ -599,9 +568,9 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     }
 
     s"Save return a $NO_CONTENT when successful" in {
-      MockPeriodSummaryService.saveGoodsToSell(journeyCtxWithNino, goodsToSellOrUseJourneyAnswers)(EitherT.rightT(()))
+      MockPeriodSummaryService.saveGoodsToSell(journeyCtxWithNino, goodsToSellOrUseJourneyAnswers)(EitherT.right[ServiceError](Future.successful(())))
       MockExpensesAnswersService.persistAnswers(
-        businessId, currTaxYear, mtditid, JourneyName.GoodsToSellOrUse, taxiMinicabOrRoadHaulageDb)(EitherT.rightT(()))
+        businessId, currTaxYear, mtditid, JourneyName.GoodsToSellOrUse, taxiMinicabOrRoadHaulageDb)(EitherT.right[ServiceError](Future.successful(())))
 
       behave like testRoute(
         request = buildRequest(goodsToSellOrUseAnswers),
@@ -615,14 +584,14 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
 
   "WorkplaceRunningCosts" should {
     s"Get return $NO_CONTENT if there is no answers" in {
-      MockExpensesAnswersService.getWorkplaceRunningCostsAnswers(journeyCtxWithNino)(EitherT.rightT(None))
+      MockExpensesAnswersService.getWorkplaceRunningCostsAnswers(journeyCtxWithNino)(EitherT.right[ServiceError](Future.successful(None)))
 
       checkNoContent(underTest.getWorkplaceRunningCosts(currTaxYear, businessId, nino))
     }
 
     s"Get answers and return a $OK when successful" in new GetExpensesTest[WorkplaceRunningCostsAnswers] {
       override val journeyAnswers: WorkplaceRunningCostsAnswers = genOne(workplaceRunningCostsAnswersGen)
-      MockExpensesAnswersService.getWorkplaceRunningCostsAnswers(journeyCtxWithNino)(EitherT.rightT(Some(journeyAnswers)))
+      MockExpensesAnswersService.getWorkplaceRunningCostsAnswers(journeyCtxWithNino)(EitherT.right[ServiceError](Future.successful(Some(journeyAnswers))))
 
       behave like testRoute(
         request = buildRequestNoContent,
@@ -633,14 +602,14 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     }
 
     s"Save return a $NO_CONTENT when successful " in {
-        MockPeriodSummaryService.saveWorkplaceRunningCosts(journeyCtxWithNino, workplaceRunningCostsJourneyAnswers)(EitherT.rightT(()))
-        MockExpensesAnswersService.persistAnswers(
-          businessId,
-          currTaxYear,
-          mtditid,
-          JourneyName.WorkplaceRunningCosts,
-          workplaceRunningCostsDb
-        )(EitherT.rightT(()))
+      MockPeriodSummaryService.saveWorkplaceRunningCosts(journeyCtxWithNino, workplaceRunningCostsJourneyAnswers)(EitherT.right[ServiceError](Future.successful(())))
+      MockExpensesAnswersService.persistAnswers(
+        businessId,
+        currTaxYear,
+        mtditid,
+        JourneyName.WorkplaceRunningCosts,
+        workplaceRunningCostsDb
+      )(EitherT.right[ServiceError](Future.successful(())))
 
       behave like testRoute(
         request = buildRequest(workplaceRunningCostsAnswers),
@@ -654,7 +623,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
   "OfficeSupplies" should {
     s"Get answers and return a $OK when successful" in new GetExpensesTest[OfficeSuppliesJourneyAnswers] {
       override val journeyAnswers: OfficeSuppliesJourneyAnswers = genOne(officeSuppliesJourneyAnswersGen)
-      MockExpensesAnswersService.getAnswers(journeyCtxWithNino)(EitherT.rightT(journeyAnswers))
+      MockExpensesAnswersService.getAnswers(journeyCtxWithNino)(EitherT.right[ServiceError](Future.successful(journeyAnswers)))
 
       behave like testRoute(
         request = buildRequestNoContent,
@@ -665,7 +634,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     }
 
     s"Save return a $NO_CONTENT when successful" in forAll(officeSuppliesJourneyAnswersGen) { data =>
-      MockPeriodSummaryService.saveOfficeSuppliesAnswers(journeyCtxWithNino, data)(EitherT.rightT(()))
+      MockPeriodSummaryService.saveOfficeSuppliesAnswers(journeyCtxWithNino, data)(EitherT.right[ServiceError](Future.successful(())))
 
       behave like testRoute(
         request = buildRequest(data),
@@ -680,7 +649,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     s"Get answers and return a $OK when successful" in new GetExpensesTest[RepairsAndMaintenanceCostsJourneyAnswers] {
       override val journeyAnswers: RepairsAndMaintenanceCostsJourneyAnswers = genOne(repairsAndMaintenanceCostsJourneyAnswersGen)
       MockExpensesAnswersService.getAnswers(journeyCtxWithNino)(
-        EitherT.rightT(journeyAnswers))
+        EitherT.right[ServiceError](Future.successful(journeyAnswers)))
 
       behave like testRoute(
         request = buildRequestNoContent,
@@ -691,7 +660,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     }
 
     s"Save return a $NO_CONTENT when successful" in forAll(repairsAndMaintenanceCostsJourneyAnswersGen) { data =>
-      MockPeriodSummaryService.saveRepairsAndMaintenance(journeyCtxWithNino, data)(EitherT.rightT(()))
+      MockPeriodSummaryService.saveRepairsAndMaintenance(journeyCtxWithNino, data)(EitherT.right[ServiceError](Future.successful(())))
 
       behave like testRoute(
         request = buildRequest(data),
@@ -706,7 +675,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     s"Get answers and return a $OK when successful" in new GetExpensesTest[StaffCostsJourneyAnswers] {
       override val journeyAnswers: StaffCostsJourneyAnswers = genOne(staffCostsJourneyAnswersGen)
       MockExpensesAnswersService.getAnswers(journeyCtxWithNino)(
-        EitherT.rightT(journeyAnswers))
+        EitherT.right[ServiceError](Future.successful(journeyAnswers)))
 
       behave like testRoute(
         request = buildRequestNoContent,
@@ -717,7 +686,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     }
 
     s"Save return a $NO_CONTENT when successful" in forAll(staffCostsJourneyAnswersGen) { data =>
-      MockPeriodSummaryService.saveStaffCosts(journeyCtxWithNino, data)(EitherT.rightT(()))
+      MockPeriodSummaryService.saveStaffCosts(journeyCtxWithNino, data)(EitherT.right[ServiceError](Future.successful(())))
 
       behave like testRoute(
         request = buildRequest(data),
@@ -730,7 +699,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
 
   "EntertainmentCosts" should {
     s"Save return a $NO_CONTENT when successful" in forAll(entertainmentCostsJourneyAnswersGen) { data =>
-      MockPeriodSummaryService.saveEntertainmentCosts(journeyCtxWithNino, data)(EitherT.rightT(()))
+      MockPeriodSummaryService.saveEntertainmentCosts(journeyCtxWithNino, data)(EitherT.right[ServiceError](Future.successful(())))
 
       behave like testRoute(
         request = buildRequest(data),
@@ -745,7 +714,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     s"Get answers and return a $OK when successful" in new GetExpensesTest[AdvertisingOrMarketingJourneyAnswers] {
       override val journeyAnswers: AdvertisingOrMarketingJourneyAnswers = genOne(advertisingOrMarketingJourneyAnswersGen)
       MockExpensesAnswersService.getAnswers(journeyCtxWithNino)(
-        EitherT.rightT(journeyAnswers))
+        EitherT.right[ServiceError](Future.successful(journeyAnswers)))
 
       behave like testRoute(
         request = buildRequestNoContent,
@@ -756,7 +725,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     }
 
     s"Save return a $NO_CONTENT when successful" in forAll(advertisingOrMarketingJourneyAnswersGen) { data =>
-      MockPeriodSummaryService.saveAdvertisingOrMarketing(journeyCtxWithNino, data)(EitherT.rightT(()))
+      MockPeriodSummaryService.saveAdvertisingOrMarketing(journeyCtxWithNino, data)(EitherT.right[ServiceError](Future.successful(())))
 
       behave like testRoute(
         request = buildRequest(data),
@@ -771,7 +740,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     s"Get answers and return a $OK when successful" in new GetExpensesTest[ConstructionJourneyAnswers] {
       override val journeyAnswers: ConstructionJourneyAnswers = genOne(constructionJourneyAnswersGen)
       MockExpensesAnswersService.getAnswers(journeyCtxWithNino)(
-        EitherT.rightT(journeyAnswers))
+        EitherT.right[ServiceError](Future.successful(journeyAnswers)))
 
       behave like testRoute(
         request = buildRequestNoContent,
@@ -782,7 +751,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     }
 
     s"Save return a $NO_CONTENT when successful" in forAll(constructionJourneyAnswersGen) { data =>
-      MockPeriodSummaryService.saveConstructionIndustrySubcontractors(journeyCtxWithNino, data)(EitherT.rightT(()))
+      MockPeriodSummaryService.saveConstructionIndustrySubcontractors(journeyCtxWithNino, data)(EitherT.right[ServiceError](Future.successful(())))
 
       behave like testRoute(
         request = buildRequest(data),
@@ -797,7 +766,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     s"Get answers and return a $OK when successful" in new GetExpensesTest[ProfessionalFeesJourneyAnswers] {
       override val journeyAnswers: ProfessionalFeesJourneyAnswers = genOne(professionalFeesJourneyAnswersGen)
       MockExpensesAnswersService.getAnswers(journeyCtxWithNino)(
-        EitherT.rightT(journeyAnswers))
+        EitherT.right[ServiceError](Future.successful(journeyAnswers)))
 
       behave like testRoute(
         request = buildRequestNoContent,
@@ -808,7 +777,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     }
 
     s"Save return a $NO_CONTENT when successful" in forAll(professionalFeesJourneyAnswersGen) { data =>
-      MockPeriodSummaryService.saveProfessionalFees(journeyCtxWithNino, data)(EitherT.rightT(()))
+      MockPeriodSummaryService.saveProfessionalFees(journeyCtxWithNino, data)(EitherT.right[ServiceError](Future.successful(())))
 
       behave like testRoute(
         request = buildRequest(data),
@@ -823,7 +792,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     s"Get answers and return a $OK when successful" in new GetExpensesTest[InterestJourneyAnswers] {
       override val journeyAnswers: InterestJourneyAnswers = genOne(interestJourneyAnswersGen)
       MockExpensesAnswersService.getAnswers(journeyCtxWithNino)(
-        EitherT.rightT(journeyAnswers))
+        EitherT.right[ServiceError](Future.successful(journeyAnswers)))
 
       behave like testRoute(
         request = buildRequestNoContent,
@@ -834,7 +803,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     }
 
     s"Save return a $NO_CONTENT when successful" in forAll(interestJourneyAnswersGen) { data =>
-      MockPeriodSummaryService.saveInterests(journeyCtxWithNino, data)(EitherT.rightT(()))
+      MockPeriodSummaryService.saveInterests(journeyCtxWithNino, data)(EitherT.right[ServiceError](Future.successful(())))
 
       behave like testRoute(
         request = buildRequest(data),
@@ -849,7 +818,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     s"Get answers and return a $OK when successful" in new GetExpensesTest[EntertainmentJourneyAnswers] {
       override val journeyAnswers: EntertainmentJourneyAnswers = genOne(entertainmentCostsJourneyAnswersGen)
       MockExpensesAnswersService.getAnswers(journeyCtxWithNino)(
-        EitherT.rightT(journeyAnswers))
+        EitherT.right[ServiceError](Future.successful(journeyAnswers)))
 
       behave like testRoute(
         request = buildRequestNoContent,
@@ -864,7 +833,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     s"Get answers and return a $OK when successful" in new GetExpensesTest[DepreciationCostsJourneyAnswers] {
       override val journeyAnswers: DepreciationCostsJourneyAnswers = genOne(depreciationJourneyAnswersGen)
       MockExpensesAnswersService.getAnswers(journeyCtxWithNino)(
-        EitherT.rightT(journeyAnswers))
+        EitherT.right[ServiceError](Future.successful(journeyAnswers)))
 
       behave like testRoute(
         request = buildRequestNoContent,
@@ -875,7 +844,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     }
 
     s"Save return a $NO_CONTENT when successful" in forAll(depreciationJourneyAnswersGen) { data =>
-      MockPeriodSummaryService.saveDepreciationCosts(journeyCtxWithNino, data)(EitherT.rightT(()))
+      MockPeriodSummaryService.saveDepreciationCosts(journeyCtxWithNino, data)(EitherT.right[ServiceError](Future.successful(())))
 
       behave like testRoute(
         request = buildRequest(data),
@@ -890,7 +859,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     s"Get answers and return a $OK when successful" in new GetExpensesTest[OtherExpensesJourneyAnswers] {
       override val journeyAnswers: OtherExpensesJourneyAnswers = genOne(otherExpensesJourneyAnswersGen)
       MockExpensesAnswersService.getAnswers(journeyCtxWithNino)(
-        EitherT.rightT(journeyAnswers))
+        EitherT.right[ServiceError](Future.successful(journeyAnswers)))
 
       behave like testRoute(
         request = buildRequestNoContent,
@@ -901,7 +870,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     }
 
     s"Save answers and return a $NO_CONTENT when successful" in forAll(otherExpensesJourneyAnswersGen) { data =>
-      MockPeriodSummaryService.saveOtherExpenses(journeyCtxWithNino, data)(EitherT.rightT(()))
+      MockPeriodSummaryService.saveOtherExpenses(journeyCtxWithNino, data)(EitherT.right[ServiceError](Future.successful(())))
 
       behave like testRoute(
         request = buildRequest(data),
@@ -916,7 +885,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     s"Get answers and return a $OK when successful" in new GetExpensesTest[FinancialChargesJourneyAnswers] {
       override val journeyAnswers: FinancialChargesJourneyAnswers = genOne(financialChargesJourneyAnswersGen)
       MockExpensesAnswersService.getAnswers(journeyCtxWithNino)(
-        EitherT.rightT(journeyAnswers))
+        EitherT.right[ServiceError](Future.successful(journeyAnswers)))
 
       behave like testRoute(
         request = buildRequestNoContent,
@@ -926,7 +895,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
       )
     }
     s"Save answers and return a $NO_CONTENT when successful" in forAll(financialChargesJourneyAnswersGen) { data =>
-      MockPeriodSummaryService.saveFinancialCharges(journeyCtxWithNino, data)(EitherT.rightT(()))
+      MockPeriodSummaryService.saveFinancialCharges(journeyCtxWithNino, data)(EitherT.right[ServiceError](Future.successful(())))
 
       behave like testRoute(
         request = buildRequest(data),
@@ -941,7 +910,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     s"Get answers and return a $OK when successful" in new GetExpensesTest[IrrecoverableDebtsJourneyAnswers] {
       override val journeyAnswers: IrrecoverableDebtsJourneyAnswers = genOne(irrecoverableDebtsJourneyAnswersGen)
       MockExpensesAnswersService.getAnswers(journeyCtxWithNino)(
-        EitherT.rightT(journeyAnswers))
+        EitherT.right[ServiceError](Future.successful(journeyAnswers)))
 
       behave like testRoute(
         request = buildRequestNoContent,
@@ -952,7 +921,7 @@ class JourneyAnswersControllerSpec extends ControllerBehaviours with ScalaCheckP
     }
 
     s"Save answers and return a $NO_CONTENT when successful" in forAll(irrecoverableDebtsJourneyAnswersGen) { data =>
-      MockPeriodSummaryService.saveBadDebts(journeyCtxWithNino, data)(EitherT.rightT(()))
+      MockPeriodSummaryService.saveBadDebts(journeyCtxWithNino, data)(EitherT.right[ServiceError](Future.successful(())))
 
       behave like testRoute(
         request = buildRequest(data),

--- a/test/controllers/actions/AuthorisedActionSpec.scala
+++ b/test/controllers/actions/AuthorisedActionSpec.scala
@@ -86,8 +86,8 @@ class AuthorisedActionSpec extends TestUtils with MockAppConfig {
 
         lazy val result: Future[Result] = {
           (mockAuthConnector
-            .authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-            .expects(*, Retrievals.allEnrolments and Retrievals.confidenceLevel, *, *)
+            .authorise(_: Predicate, _: Retrieval[Any])(_: HeaderCarrier, _: ExecutionContext))
+            .expects(*, (Retrievals.allEnrolments and Retrievals.confidenceLevel).asInstanceOf[Retrieval[Any]], *, *)
             .returning(Future.successful(enrolments and ConfidenceLevel.L250))
           auth.individualAuthentication(block, testMtditid)(fakeRequest, emptyHeaderCarrier)
         }
@@ -111,8 +111,8 @@ class AuthorisedActionSpec extends TestUtils with MockAppConfig {
 
         lazy val result: Future[Result] = {
           (mockAuthConnector
-            .authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-            .expects(*, Retrievals.allEnrolments and Retrievals.confidenceLevel, *, *)
+            .authorise(_: Predicate, _: Retrieval[Any])(_: HeaderCarrier, _: ExecutionContext))
+            .expects(*, (Retrievals.allEnrolments and Retrievals.confidenceLevel).asInstanceOf[Retrieval[Any]], *, *)
             .returning(Future.successful(enrolments and ConfidenceLevel.L250))
           auth.individualAuthentication(block, testMtditid)(fakeRequest, emptyHeaderCarrier)
         }
@@ -131,8 +131,8 @@ class AuthorisedActionSpec extends TestUtils with MockAppConfig {
 
         lazy val result: Future[Result] = {
           (mockAuthConnector
-            .authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-            .expects(*, Retrievals.allEnrolments and Retrievals.confidenceLevel, *, *)
+            .authorise(_: Predicate, _: Retrieval[Any])(_: HeaderCarrier, _: ExecutionContext))
+            .expects(*, (Retrievals.allEnrolments and Retrievals.confidenceLevel).asInstanceOf[Retrieval[Any]], *, *)
             .returning(Future.successful(enrolments and ConfidenceLevel.L50))
           auth.individualAuthentication(block, testMtditid)(fakeRequest, emptyHeaderCarrier)
         }
@@ -149,8 +149,8 @@ class AuthorisedActionSpec extends TestUtils with MockAppConfig {
 
         lazy val result: Future[Result] = {
           (mockAuthConnector
-            .authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-            .expects(*, Retrievals.allEnrolments and Retrievals.confidenceLevel, *, *)
+            .authorise(_: Predicate, _: Retrieval[Any])(_: HeaderCarrier, _: ExecutionContext))
+            .expects(*, (Retrievals.allEnrolments and Retrievals.confidenceLevel).asInstanceOf[Retrieval[Any]], *, *)
             .returning(Future.successful(enrolments and ConfidenceLevel.L250))
           auth.individualAuthentication(block, testMtditid)(fakeRequest, emptyHeaderCarrier)
         }
@@ -165,8 +165,8 @@ class AuthorisedActionSpec extends TestUtils with MockAppConfig {
 
         lazy val result: Future[Result] = {
           (mockAuthConnector
-            .authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-            .expects(*, Retrievals.allEnrolments and Retrievals.confidenceLevel, *, *)
+            .authorise(_: Predicate, _: Retrieval[Any])(_: HeaderCarrier, _: ExecutionContext))
+            .expects(*, (Retrievals.allEnrolments and Retrievals.confidenceLevel).asInstanceOf[Retrieval[Any]], *, *)
             .returning(Future.successful(enrolments and ConfidenceLevel.L250))
           auth.individualAuthentication(block, testNino)(fakeRequest, emptyHeaderCarrier)
         }
@@ -186,8 +186,8 @@ class AuthorisedActionSpec extends TestUtils with MockAppConfig {
 
         lazy val result: Future[Result] = {
           (mockAuthConnector
-            .authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-            .expects(*, Retrievals.allEnrolments and Retrievals.confidenceLevel, *, *)
+            .authorise(_: Predicate, _: Retrieval[Any])(_: HeaderCarrier, _: ExecutionContext))
+            .expects(*, (Retrievals.allEnrolments and Retrievals.confidenceLevel).asInstanceOf[Retrieval[Any]], *, *)
             .returning(Future.successful(enrolments and ConfidenceLevel.L250))
           auth.individualAuthentication(block, testMtditid)(fakeRequest, emptyHeaderCarrier)
         }
@@ -208,8 +208,8 @@ class AuthorisedActionSpec extends TestUtils with MockAppConfig {
 
       lazy val result: Future[Result] = {
         (mockAuthConnector
-          .authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-          .expects(*, Retrievals.allEnrolments and Retrievals.confidenceLevel, *, *)
+          .authorise(_: Predicate, _: Retrieval[Any])(_: HeaderCarrier, _: ExecutionContext))
+          .expects(*, (Retrievals.allEnrolments and Retrievals.confidenceLevel).asInstanceOf[Retrieval[Any]], *, *)
           .returning(Future.successful(enrolments and ConfidenceLevel.L250))
         auth.individualAuthentication(block, testMtditid)(fakeRequest, emptyHeaderCarrier)
       }
@@ -228,8 +228,8 @@ class AuthorisedActionSpec extends TestUtils with MockAppConfig {
 
       lazy val result: Future[Result] = {
         (mockAuthConnector
-          .authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-          .expects(*, Retrievals.allEnrolments and Retrievals.confidenceLevel, *, *)
+          .authorise(_: Predicate, _: Retrieval[Any])(_: HeaderCarrier, _: ExecutionContext))
+          .expects(*, (Retrievals.allEnrolments and Retrievals.confidenceLevel).asInstanceOf[Retrieval[Any]], *, *)
           .returning(Future.successful(enrolments and ConfidenceLevel.L50))
         auth.individualAuthentication(block, testMtditid)(fakeRequest, emptyHeaderCarrier)
       }
@@ -246,8 +246,8 @@ class AuthorisedActionSpec extends TestUtils with MockAppConfig {
 
       lazy val result: Future[Result] = {
         (mockAuthConnector
-          .authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-          .expects(*, Retrievals.allEnrolments and Retrievals.confidenceLevel, *, *)
+          .authorise(_: Predicate, _: Retrieval[Any])(_: HeaderCarrier, _: ExecutionContext))
+          .expects(*, (Retrievals.allEnrolments and Retrievals.confidenceLevel).asInstanceOf[Retrieval[Any]], *, *)
           .returning(Future.successful(enrolments and ConfidenceLevel.L250))
         auth.individualAuthentication(block, testMtditid)(fakeRequest, emptyHeaderCarrier)
       }
@@ -262,8 +262,8 @@ class AuthorisedActionSpec extends TestUtils with MockAppConfig {
 
       lazy val result: Future[Result] = {
         (mockAuthConnector
-          .authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-          .expects(*, Retrievals.allEnrolments and Retrievals.confidenceLevel, *, *)
+          .authorise(_: Predicate, _: Retrieval[Any])(_: HeaderCarrier, _: ExecutionContext))
+          .expects(*, (Retrievals.allEnrolments and Retrievals.confidenceLevel).asInstanceOf[Retrieval[Any]], *, *)
           .returning(Future.successful(enrolments and ConfidenceLevel.L250))
         auth.individualAuthentication(block, testNino)(fakeRequest, emptyHeaderCarrier)
       }
@@ -285,8 +285,8 @@ class AuthorisedActionSpec extends TestUtils with MockAppConfig {
 
         lazy val result = {
           (mockAuthConnector
-            .authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-            .expects(*, Retrievals.allEnrolments, *, *)
+            .authorise(_: Predicate, _: Retrieval[Any])(_: HeaderCarrier, _: ExecutionContext))
+            .expects(*, Retrievals.allEnrolments.asInstanceOf[Retrieval[Any]], *, *)
             .returning(Future.successful(enrolments))
 
           auth.agentAuthentication(block, testMtditid)(fakeRequest, emptyHeaderCarrier)
@@ -323,8 +323,8 @@ class AuthorisedActionSpec extends TestUtils with MockAppConfig {
 
         lazy val result = {
           (mockAuthConnector
-            .authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-            .expects(*, Retrievals.allEnrolments, *, *)
+            .authorise(_: Predicate, _: Retrieval[Any])(_: HeaderCarrier, _: ExecutionContext))
+            .expects(*, Retrievals.allEnrolments.asInstanceOf[Retrieval[Any]], *, *)
             .returning(Future.successful(enrolments))
           auth.agentAuthentication(block, testMtditid)(fakeRequest, emptyHeaderCarrier)
         }

--- a/test/mocks/MockAuth.scala
+++ b/test/mocks/MockAuth.scala
@@ -18,7 +18,8 @@ package mocks
 
 import common._
 import controllers.actions.AuthorisedAction
-import org.mockito.IdiomaticMockito.StubbingOps
+import org.mockito.ArgumentMatchers.{any, `eq` as eqTo}
+import org.mockito.Mockito.when
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.auth.core.syntax.retrieved.authSyntaxForRetrieved
@@ -36,13 +37,13 @@ trait MockAuth extends BaseSpec with MockAppConfig {
       Enrolment(EnrolmentKeys.nino, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.nino, "1234567890")), "Activated")
     ))
 
-  mockAuthConnector
-    .authorise(*, eqTo(Retrievals.allEnrolments and Retrievals.confidenceLevel))(*, *) returns Future
-    .successful(individualEnrolments and ConfidenceLevel.L250)
+  when(mockAuthConnector
+    .authorise(any(), eqTo(Retrievals.allEnrolments and Retrievals.confidenceLevel))(any(), any()))
+    .thenReturn(Future.successful(individualEnrolments and ConfidenceLevel.L250))
 
-  mockAuthConnector
-    .authorise(*, eqTo(Retrievals.affinityGroup))(*, *) returns Future
-    .successful(Some(AffinityGroup.Individual))
+  when(mockAuthConnector
+    .authorise(any(), eqTo(Retrievals.affinityGroup))(any(), any()))
+    .thenReturn(Future.successful(Some(AffinityGroup.Individual)))
 
   protected val mockAuthorisedAction = new AuthorisedAction()(mockAuthConnector, defaultActionBuilder, stubControllerComponents)
 

--- a/test/mocks/connectors/MockBusinessDetailsConnector.scala
+++ b/test/mocks/connectors/MockBusinessDetailsConnector.scala
@@ -22,9 +22,9 @@ import models.common.{BusinessId, Mtditid, Nino}
 import models.connector.businessDetailsConnector.BusinessDetailsHipSuccessWrapper
 import models.domain.ApiResultT
 import models.error.ServiceError
-import org.mockito.ArgumentMatchersSugar.{any, eqTo}
-import org.mockito.MockitoSugar.when
-import org.mockito.stubbing.ScalaOngoingStubbing
+import org.mockito.ArgumentMatchersSugar.*
+import org.mockito.Mockito.when
+import org.mockito.stubbing.OngoingStubbing as ScalaOngoingStubbing
 import org.scalatestplus.mockito.MockitoSugar.mock
 import uk.gov.hmrc.http.HeaderCarrier
 

--- a/test/mocks/connectors/MockHipReliefClaimsConnector.scala
+++ b/test/mocks/connectors/MockHipReliefClaimsConnector.scala
@@ -17,22 +17,22 @@
 package mocks.connectors
 
 import cats.data.EitherT
-import cats.implicits.catsStdInstancesForFuture
 import connectors.HIP.HipReliefClaimsConnector
 import models.common.JourneyContextWithNino
 import models.connector.ReliefClaimType
 import models.connector.api_1505.ClaimId
 import models.domain.ApiResultT
+import models.error.ServiceError
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
-import org.mockito.ArgumentMatchersSugar.eqTo
-import org.mockito.MockitoSugar.when
-import org.mockito.stubbing.ScalaOngoingStubbing
+import org.mockito.ArgumentMatchers.{`eq` as eqTo}
+import org.mockito.Mockito.when
+import org.mockito.stubbing.OngoingStubbing as ScalaOngoingStubbing
 import org.scalatestplus.mockito.MockitoSugar.mock
 import uk.gov.hmrc.http.HeaderCarrier
 
-import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ExecutionContext, Future}
 
 object MockHipReliefClaimsConnector {
 
@@ -40,9 +40,9 @@ object MockHipReliefClaimsConnector {
 
   def deleteReliefClaim(ctx: JourneyContextWithNino, claimId: String): ScalaOngoingStubbing[ApiResultT[Unit]] =
     when(mockInstance.deleteReliefClaim(eqTo(ctx), eqTo(claimId))(any[HeaderCarrier], any[ExecutionContext]))
-      .thenReturn(EitherT.pure(()))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(())))
 
   def createReliefClaim(ctx: JourneyContextWithNino, answer: ReliefClaimType)(returnValue: ClaimId): ScalaOngoingStubbing[ApiResultT[ClaimId]] =
-    when(mockInstance.createReliefClaim(ArgumentMatchers.eq(ctx), ArgumentMatchers.eq(answer))(any())).thenReturn(EitherT.pure(returnValue))
+    when(mockInstance.createReliefClaim(ArgumentMatchers.eq(ctx), ArgumentMatchers.eq(answer))(any())).thenReturn(EitherT.right[ServiceError](Future.successful(returnValue)))
 
 }

--- a/test/mocks/connectors/MockIFSBusinessDetailsConnector.scala
+++ b/test/mocks/connectors/MockIFSBusinessDetailsConnector.scala
@@ -25,10 +25,9 @@ import models.domain.ApiResultT
 import models.connector.api_1871.BusinessIncomeSourcesSummaryResponse
 import models.connector.api_2085
 import models.connector.businessDetailsConnector.BusinessDetailsSuccessResponseSchema
-import org.mockito.stubbing.ScalaOngoingStubbing
-import org.mockito.ArgumentMatchersSugar.eqTo
-import org.mockito.ArgumentMatchersSugar.any
-import org.mockito.MockitoSugar.when
+import org.mockito.ArgumentMatchersSugar.*
+import org.mockito.Mockito.when
+import org.mockito.stubbing.OngoingStubbing as ScalaOngoingStubbing
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/test/mocks/connectors/MockIFSConnector.scala
+++ b/test/mocks/connectors/MockIFSConnector.scala
@@ -17,7 +17,6 @@
 package mocks.connectors
 
 import cats.data.EitherT
-import cats.implicits._
 import connectors.IFS.IFSConnector
 import connectors.IFS.IFSConnector.{Api1786Response, Api1803Response, Api1895Response}
 import models.common.JourneyContextWithNino
@@ -26,10 +25,11 @@ import models.connector.api_1639.SuccessResponseAPI1639
 import models.connector.api_1802.request.CreateAmendSEAnnualSubmissionRequestBody
 import models.connector.api_1895.request.AmendSEPeriodSummaryRequestData
 import models.domain.ApiResultT
+import models.error.ServiceError
 import org.mockito.ArgumentMatchers.any
-import org.mockito.ArgumentMatchersSugar.eqTo
-import org.mockito.MockitoSugar.when
-import org.mockito.stubbing.ScalaOngoingStubbing
+import org.mockito.ArgumentMatchers.{`eq` as eqTo}
+import org.mockito.Mockito.when
+import org.mockito.stubbing.OngoingStubbing as ScalaOngoingStubbing
 import org.scalatestplus.mockito.MockitoSugar.mock
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -43,15 +43,15 @@ object MockIFSConnector {
   def getDisclosuresSubmission(ctx: JourneyContextWithNino)
                               (returnValue: Option[SuccessResponseAPI1639]): ScalaOngoingStubbing[ApiResultT[Option[SuccessResponseAPI1639]]] =
     when(mockInstance.getDisclosuresSubmission(eqTo(ctx))(any[HeaderCarrier], any[ExecutionContext]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(returnValue)))
 
   def upsertDisclosuresSubmission(ctx: JourneyContextWithNino, data: RequestSchemaAPI1638): ScalaOngoingStubbing[ApiResultT[Unit]] =
     when(mockInstance.upsertDisclosuresSubmission(eqTo(ctx), eqTo(data))(any[HeaderCarrier], any[ExecutionContext]))
-      .thenReturn(EitherT.rightT(()))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(())))
 
   def deleteDisclosuresSubmission(ctx: JourneyContextWithNino): ScalaOngoingStubbing[ApiResultT[Unit]] =
     when(mockInstance.deleteDisclosuresSubmission(eqTo(ctx))(any[HeaderCarrier], any[ExecutionContext]))
-      .thenReturn(EitherT.rightT(()))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(())))
 
   def getAnnualSummaries(ctx: JourneyContextWithNino)(response: Api1803Response): ScalaOngoingStubbing[Future[Api1803Response]] =
     when(mockInstance.getAnnualSummaries(eqTo(ctx))(any[HeaderCarrier], any[ExecutionContext]))
@@ -60,7 +60,7 @@ object MockIFSConnector {
   def createUpdateOrDeleteApiAnnualSummaries(ctx: JourneyContextWithNino,
                                              requestBody: Option[CreateAmendSEAnnualSubmissionRequestBody]): ScalaOngoingStubbing[ApiResultT[Unit]] =
     when(mockInstance.createUpdateOrDeleteApiAnnualSummaries(eqTo(ctx), eqTo(requestBody))(any[HeaderCarrier], any[ExecutionContext]))
-      .thenReturn(EitherT.rightT(()))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(())))
 
   def getPeriodicSummaryDetail(ctx: JourneyContextWithNino)(returnValue: Api1786Response): ScalaOngoingStubbing[Future[Api1786Response]] =
     when(mockInstance.getPeriodicSummaryDetail(eqTo(ctx))(any[HeaderCarrier], any[ExecutionContext]))
@@ -71,8 +71,9 @@ object MockIFSConnector {
 //    when(mockInstance.amendSEPeriodSummary(eqTo(data))(any[HeaderCarrier], any[ExecutionContext]))
 //      .thenReturn(Future.successful(returnValue))
 
-    def amendSEPeriodSummary()(returnValue: Api1895Response): ScalaOngoingStubbing[Future[Api1895Response]] =
-      when(mockInstance.amendSEPeriodSummary(any[AmendSEPeriodSummaryRequestData])(any[HeaderCarrier], any[ExecutionContext]))
-        .thenReturn(Future.successful(returnValue))
+  def amendSEPeriodSummary()(returnValue: Api1895Response): ScalaOngoingStubbing[Future[Api1895Response]] = {
+    when(mockInstance.amendSEPeriodSummary(any[AmendSEPeriodSummaryRequestData])(any[HeaderCarrier], any[ExecutionContext]))
+      .thenReturn(Future.successful(returnValue))
+  }
 
 }

--- a/test/mocks/connectors/MockIncomeSourcesConnector.scala
+++ b/test/mocks/connectors/MockIncomeSourcesConnector.scala
@@ -22,10 +22,9 @@ import models.common.Nino
 import models.connector.ApiResponse
 import models.connector.api_2085.ListOfIncomeSources
 import models.domain.ApiResultT
-import org.mockito.ArgumentMatchers.any
-import org.mockito.ArgumentMatchersSugar.eqTo
-import org.mockito.MockitoSugar.when
-import org.mockito.stubbing.ScalaOngoingStubbing
+import org.mockito.ArgumentMatchersSugar.*
+import org.mockito.Mockito.when
+import org.mockito.stubbing.OngoingStubbing as ScalaOngoingStubbing
 import org.scalatestplus.mockito.MockitoSugar.mock
 import uk.gov.hmrc.http.HeaderCarrier
 

--- a/test/mocks/connectors/MockReliefClaimsConnector.scala
+++ b/test/mocks/connectors/MockReliefClaimsConnector.scala
@@ -17,7 +17,6 @@
 package mocks.connectors
 
 import cats.data.EitherT
-import cats.implicits.catsStdInstancesForFuture
 import connectors.ReliefClaimsConnector
 import models.common.JourneyContextWithNino
 import models.connector.ReliefClaimType
@@ -27,36 +26,37 @@ import models.domain.ApiResultT
 import models.error.ServiceError
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
-import org.mockito.ArgumentMatchersSugar.eqTo
-import org.mockito.MockitoSugar.when
-import org.mockito.stubbing.ScalaOngoingStubbing
+import org.mockito.ArgumentMatchers.{`eq` as eqTo}
+import org.mockito.Mockito.when
+import org.mockito.stubbing.OngoingStubbing as ScalaOngoingStubbing
 import org.scalatestplus.mockito.MockitoSugar.mock
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 object MockReliefClaimsConnector {
 
   val mockInstance: ReliefClaimsConnector = mock[ReliefClaimsConnector]
 
   def createReliefClaim(ctx: JourneyContextWithNino, answer: ReliefClaimType)(returnValue: ClaimId): ScalaOngoingStubbing[ApiResultT[ClaimId]] =
-    when(mockInstance.createReliefClaim(ArgumentMatchers.eq(ctx), ArgumentMatchers.eq(answer))(any())).thenReturn(EitherT.pure(returnValue))
+    when(mockInstance.createReliefClaim(ArgumentMatchers.eq(ctx), ArgumentMatchers.eq(answer))(any())).thenReturn(EitherT.right[ServiceError](Future.successful(returnValue)))
 
   def createReliefClaimError(ctx: JourneyContextWithNino, answer: ReliefClaimType)(
       returnValue: ServiceError): ScalaOngoingStubbing[ApiResultT[ClaimId]] =
     when(mockInstance.createReliefClaim(eqTo(ctx), eqTo(answer))(any()))
-      .thenReturn(EitherT.leftT(returnValue))
+      .thenReturn(EitherT.left[ClaimId](Future.successful(returnValue: ServiceError)))
 
   def deleteReliefClaim(ctx: JourneyContextWithNino, claimId: String): ScalaOngoingStubbing[ApiResultT[Unit]] =
     when(mockInstance.deleteReliefClaim(eqTo(ctx), eqTo(claimId))(any()))
-      .thenReturn(EitherT.pure(()))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(())))
 
   def getAllReliefClaims(ctx: JourneyContextWithNino)(returnValue: List[ReliefClaim]): ScalaOngoingStubbing[ApiResultT[List[ReliefClaim]]] =
     when(mockInstance.getAllReliefClaims(eqTo(ctx))(any[HeaderCarrier]))
-      .thenReturn(EitherT.pure(returnValue))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(returnValue)))
 
   def getAllReliefClaimsError(ctx: JourneyContextWithNino)(returnValue: ServiceError): ScalaOngoingStubbing[ApiResultT[List[ReliefClaim]]] =
     when(mockInstance.getAllReliefClaims(eqTo(ctx))(any()))
-      .thenReturn(EitherT.leftT(returnValue))
+      .thenReturn(EitherT.left[List[ReliefClaim]](Future.successful(returnValue: ServiceError)))
 
 }

--- a/test/mocks/repositories/MockJourneyAnswersRepository.scala
+++ b/test/mocks/repositories/MockJourneyAnswersRepository.scala
@@ -17,16 +17,15 @@
 package mocks.repositories
 
 import cats.data.EitherT
-import cats.implicits._
 import models.common._
 import models.database.JourneyAnswers
 import models.domain.{ApiResultT, Business}
 import models.error.DownstreamError.SingleDownstreamError
+import models.error.ServiceError
 import models.frontend.TaskList
-import org.mockito.ArgumentMatchers.any
-import org.mockito.ArgumentMatchersSugar.eqTo
-import org.mockito.MockitoSugar.when
-import org.mockito.stubbing.ScalaOngoingStubbing
+import org.mockito.ArgumentMatchersSugar.*
+import org.mockito.Mockito.when
+import org.mockito.stubbing.OngoingStubbing as ScalaOngoingStubbing
 import org.scalatestplus.mockito.MockitoSugar.mock
 import play.api.libs.json.JsValue
 import repositories.JourneyAnswersRepository
@@ -57,34 +56,34 @@ object MockJourneyAnswersRepository {
   def get(context: JourneyContext)
          (returnValue: Option[JourneyAnswers]): ScalaOngoingStubbing[ApiResultT[Option[JourneyAnswers]]] =
     when(mockInstance.get(eqTo(context)))
-      .thenReturn(EitherT.pure(returnValue))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(returnValue)))
 
   def getAll(taxYear: TaxYear, mtdId: Mtditid, businesses: List[Business])
             (returnValue: TaskList): ScalaOngoingStubbing[ApiResultT[TaskList]] =
     when(mockInstance.getAll(eqTo(taxYear), eqTo(mtdId), eqTo(businesses)))
-      .thenReturn(EitherT.pure(returnValue))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(returnValue)))
 
   def getAllError(taxYear: TaxYear, mtdId: Mtditid, businesses: List[Business])
                  (returnValue: SingleDownstreamError): ScalaOngoingStubbing[ApiResultT[TaskList]] =
     when(mockInstance.getAll(eqTo(taxYear), eqTo(mtdId), eqTo(businesses)))
-      .thenReturn(EitherT.leftT(returnValue))
+      .thenReturn(EitherT.left[TaskList](Future.successful(returnValue: ServiceError)))
 
   def getAnswers[A](ctx: JourneyContext)
                           (returnValue: Option[A]): ScalaOngoingStubbing[ApiResultT[Option[A]]] =
     when(mockInstance.getAnswers[A](eqTo(ctx))(any()))
-      .thenReturn(EitherT.pure(returnValue))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(returnValue)))
 
   def upsertAnswers(ctx: JourneyContext, newData: JsValue): ScalaOngoingStubbing[ApiResultT[Unit]] =
     when(mockInstance.upsertAnswers(eqTo(ctx), eqTo(newData)))
-      .thenReturn(EitherT.pure(()))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(())))
 
   def setStatus(ctx: JourneyContext, status: JourneyStatus): ScalaOngoingStubbing[ApiResultT[Unit]] =
     when(mockInstance.setStatus(eqTo(ctx), eqTo(status)))
-      .thenReturn(EitherT.pure(()))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(())))
 
   def deleteOneOrMoreJourneys(ctx: JourneyContext, multiplePrefix: Option[String] = None): ScalaOngoingStubbing[ApiResultT[Unit]] =
     when(
       mockInstance.deleteOneOrMoreJourneys(eqTo(ctx), eqTo(multiplePrefix)))
-      .thenReturn(EitherT.pure(()))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(())))
 
 }

--- a/test/mocks/services/MockBusinessService.scala
+++ b/test/mocks/services/MockBusinessService.scala
@@ -21,17 +21,18 @@ import models.common.{BusinessId, JourneyContextWithNino, Mtditid, Nino, TaxYear
 import models.connector.api_1871.BusinessIncomeSourcesSummaryResponse
 import models.connector.businessDetailsConnector.BusinessDetailsSuccessResponseSchema
 import models.domain.{ApiResultT, Business}
+import models.error.ServiceError
 import models.frontend.adjustments.NetBusinessProfitOrLossValues
-import org.mockito.ArgumentMatchersSugar.{any, eqTo}
-import org.mockito.MockitoSugar.when
-import org.mockito.stubbing.ScalaOngoingStubbing
+import org.mockito.ArgumentMatchersSugar.*
+import org.mockito.Mockito.when
+import org.mockito.stubbing.OngoingStubbing as ScalaOngoingStubbing
 import org.scalatestplus.mockito.MockitoSugar.mock
 import services.BusinessService
 import uk.gov.hmrc.http.HeaderCarrier
 
 import java.time.LocalDate
-import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ExecutionContext, Future}
 
 object MockBusinessService {
 
@@ -40,54 +41,54 @@ object MockBusinessService {
   def getBusinessDetails(businessId: Option[BusinessId], mtditid: Mtditid, nino: Nino)
                         (returnValue: BusinessDetailsSuccessResponseSchema):
   ScalaOngoingStubbing[ApiResultT[Option[BusinessDetailsSuccessResponseSchema]]] = {
-    when(mockInstance.getBusinessDetails(eqTo(businessId), eqTo(mtditid), eqTo(nino))(any[HeaderCarrier], any[ExecutionContext]))
-      .thenReturn(EitherT.rightT(Some(returnValue)))
+    when(mockInstance.getBusinessDetails(eqTo(businessId), any[Mtditid](), any[Nino]())(any[HeaderCarrier], any[ExecutionContext]))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(Some(returnValue))))
   }
 
   def getBusiness(businessId: BusinessId, mtditid: Mtditid, nino: Nino)
                  (returnValue: Business):
   ScalaOngoingStubbing[ApiResultT[Business]] = {
     when(mockInstance.getBusiness(eqTo(businessId), eqTo(mtditid), eqTo(nino))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(returnValue)))
   }
 
   def getBusinesses(mtditid: Mtditid, nino: Nino)
                    (returnValue: List[Business]):
   ScalaOngoingStubbing[ApiResultT[List[Business]]] = {
     when(mockInstance.getBusinesses(eqTo(mtditid), eqTo(nino))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(returnValue)))
   }
 
   def getUserBusinessIds(mtditid: Mtditid, nino: Nino)
                         (returnValue: List[BusinessId]):
   ScalaOngoingStubbing[ApiResultT[List[BusinessId]]] = {
     when(mockInstance.getUserBusinessIds(eqTo(mtditid), eqTo(nino))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(returnValue)))
   }
 
   def getUserDateOfBirth(nino: Nino)
                         (returnValue: LocalDate): ScalaOngoingStubbing[ApiResultT[LocalDate]] =
     when(mockInstance.getUserDateOfBirth(eqTo(nino))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(returnValue)))
 
   def getAllBusinessIncomeSourcesSummaries(taxYear: TaxYear, mtditid: Mtditid, nino: Nino)
                                           (returnValue: List[BusinessIncomeSourcesSummaryResponse]): ScalaOngoingStubbing[ApiResultT[List[BusinessIncomeSourcesSummaryResponse]]] =
     when(mockInstance.getAllBusinessIncomeSourcesSummaries(eqTo(taxYear), eqTo(mtditid), eqTo(nino))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(returnValue)))
 
   def getBusinessIncomeSourcesSummary(taxYear: TaxYear, nino: Nino, businessId: BusinessId)
                                      (returnValue: BusinessIncomeSourcesSummaryResponse): ScalaOngoingStubbing[ApiResultT[BusinessIncomeSourcesSummaryResponse]] =
     when(mockInstance.getBusinessIncomeSourcesSummary(eqTo(taxYear), eqTo(nino), eqTo(businessId))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(returnValue)))
 
   def getNetBusinessProfitOrLossValues(ctx: JourneyContextWithNino)
                                       (returnValue: NetBusinessProfitOrLossValues): ScalaOngoingStubbing[ApiResultT[NetBusinessProfitOrLossValues]] =
     when(mockInstance.getNetBusinessProfitOrLossValues(eqTo(ctx))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(returnValue)))
 
   def hasOtherIncomeSources(taxYear: TaxYear, nino: Nino)
                            (returnValue: Boolean): ScalaOngoingStubbing[ApiResultT[Boolean]] =
     when(mockInstance.hasOtherIncomeSources(eqTo(taxYear), eqTo(nino))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(returnValue)))
 
 }

--- a/test/mocks/services/MockExpensesAnswersService.scala
+++ b/test/mocks/services/MockExpensesAnswersService.scala
@@ -16,23 +16,20 @@
 
 package mocks.services
 
-import cats.data.EitherT
 import models.common._
 import models.connector.Api1786ExpensesResponseParser
 import models.domain.ApiResultT
 import models.frontend.expenses.goodsToSellOrUse.GoodsToSellOrUseAnswers
 import models.frontend.expenses.tailoring.ExpensesTailoringAnswers
 import models.frontend.expenses.workplaceRunningCosts.WorkplaceRunningCostsAnswers
-import org.mockito.ArgumentMatchers.any
-import org.mockito.stubbing.ScalaOngoingStubbing
-import org.mockito.ArgumentMatchersSugar.eqTo
-import org.mockito.MockitoSugar.when
+import org.mockito.ArgumentMatchersSugar.*
+import org.mockito.Mockito.when
+import org.mockito.stubbing.OngoingStubbing as ScalaOngoingStubbing
 import org.scalatestplus.mockito.MockitoSugar.mock
 import play.api.libs.json.Writes
 import services.journeyAnswers.expenses.ExpensesAnswersService
 import uk.gov.hmrc.http.HeaderCarrier
 
-import scala.concurrent.ExecutionContext.Implicits.global
 
 object MockExpensesAnswersService {
 
@@ -47,7 +44,7 @@ object MockExpensesAnswersService {
   def saveTailoringAnswers(ctx: JourneyContextWithNino, answers: ExpensesTailoringAnswers)
                               (returnValue: ApiResultT[Unit]): ScalaOngoingStubbing[ApiResultT[Unit]] = {
     when(mockInstance.saveTailoringAnswers(eqTo(ctx), eqTo(answers))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(returnValue)
   }
 
   def getAnswers[A](ctx: JourneyContextWithNino)
@@ -81,19 +78,19 @@ object MockExpensesAnswersService {
   def deleteSimplifiedExpensesAnswers(ctx: JourneyContextWithNino)
                                      (returnValue: ApiResultT[Unit]): ScalaOngoingStubbing[ApiResultT[Unit]] = {
     when(mockInstance.deleteSimplifiedExpensesAnswers(eqTo(ctx))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(returnValue)
   }
 
   def clearExpensesAndCapitalAllowancesData(ctx: JourneyContextWithNino)
                                            (returnValue: ApiResultT[Unit]): ScalaOngoingStubbing[ApiResultT[Unit]] = {
     when(mockInstance.clearExpensesAndCapitalAllowancesData(eqTo(ctx))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(returnValue)
   }
 
   def clearExpensesData(ctx: JourneyContextWithNino, journeyName: JourneyName)
                        (returnValue: ApiResultT[Unit]): ScalaOngoingStubbing[ApiResultT[Unit]] = {
     when(mockInstance.clearExpensesData(eqTo(ctx), eqTo(journeyName))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(returnValue)
   }
 
 }

--- a/test/mocks/services/MockPeriodSummaryService.scala
+++ b/test/mocks/services/MockPeriodSummaryService.scala
@@ -16,7 +16,6 @@
 
 package mocks.services
 
-import cats.data.EitherT
 import models.common._
 import models.database.expenses.travel.TravelExpensesDb
 import models.domain.ApiResultT
@@ -35,14 +34,13 @@ import models.frontend.expenses.repairsandmaintenance.RepairsAndMaintenanceCosts
 import models.frontend.expenses.staffcosts.StaffCostsJourneyAnswers
 import models.frontend.expenses.workplaceRunningCosts.WorkplaceRunningCostsJourneyAnswers
 import org.mockito.ArgumentMatchers.any
-import org.mockito.stubbing.ScalaOngoingStubbing
-import org.mockito.ArgumentMatchersSugar.eqTo
-import org.mockito.MockitoSugar.when
+import org.mockito.ArgumentMatchers.{`eq` as eqTo}
+import org.mockito.Mockito.when
+import org.mockito.stubbing.OngoingStubbing as ScalaOngoingStubbing
 import org.scalatestplus.mockito.MockitoSugar.mock
 import services.journeyAnswers.expenses.PeriodSummaryService
 import uk.gov.hmrc.http.HeaderCarrier
 
-import scala.concurrent.ExecutionContext.Implicits.global
 
 
 object MockPeriodSummaryService {
@@ -53,91 +51,91 @@ object MockPeriodSummaryService {
   def saveTravelExpenses(ctx: JourneyContextWithNino, answers: TravelExpensesDb)
                        (returnValue: ApiResultT[Unit]): ScalaOngoingStubbing[ApiResultT[Unit]] = {
     when(mockInstance.saveTravelExpenses(eqTo(ctx), eqTo(answers))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(returnValue)
   }
 
   def saveOfficeSuppliesAnswers(ctx: JourneyContextWithNino, answers: OfficeSuppliesJourneyAnswers)
                         (returnValue: ApiResultT[Unit]): ScalaOngoingStubbing[ApiResultT[Unit]] = {
     when(mockInstance.saveOfficeSuppliesAnswers(eqTo(ctx), eqTo(answers))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(returnValue)
   }
 
   def saveGoodsToSell(ctx: JourneyContextWithNino, answers: GoodsToSellOrUseJourneyAnswers)
                                (returnValue: ApiResultT[Unit]): ScalaOngoingStubbing[ApiResultT[Unit]] = {
     when(mockInstance.saveGoodsToSell(eqTo(ctx), eqTo(answers))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(returnValue)
   }
 
   def saveRepairsAndMaintenance(ctx: JourneyContextWithNino, answers: RepairsAndMaintenanceCostsJourneyAnswers)
                      (returnValue: ApiResultT[Unit]): ScalaOngoingStubbing[ApiResultT[Unit]] = {
     when(mockInstance.saveRepairsAndMaintenance(eqTo(ctx), eqTo(answers))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(returnValue)
   }
 
   def saveWorkplaceRunningCosts(ctx: JourneyContextWithNino, answers: WorkplaceRunningCostsJourneyAnswers)
                                (returnValue: ApiResultT[Unit]): ScalaOngoingStubbing[ApiResultT[Unit]] = {
     when(mockInstance.saveWorkplaceRunningCosts(eqTo(ctx), eqTo(answers))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(returnValue)
   }
 
   def saveAdvertisingOrMarketing(ctx: JourneyContextWithNino, answers: AdvertisingOrMarketingJourneyAnswers)
                                (returnValue: ApiResultT[Unit]): ScalaOngoingStubbing[ApiResultT[Unit]] = {
     when(mockInstance.saveAdvertisingOrMarketing(eqTo(ctx), eqTo(answers))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(returnValue)
   }
 
   def saveEntertainmentCosts(ctx: JourneyContextWithNino, answers: EntertainmentJourneyAnswers)
                                 (returnValue: ApiResultT[Unit]): ScalaOngoingStubbing[ApiResultT[Unit]] = {
     when(mockInstance.saveEntertainmentCosts(eqTo(ctx), eqTo(answers))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(returnValue)
   }
 
   def saveStaffCosts(ctx: JourneyContextWithNino, answers: StaffCostsJourneyAnswers)
                             (returnValue: ApiResultT[Unit]): ScalaOngoingStubbing[ApiResultT[Unit]] = {
     when(mockInstance.saveStaffCosts(eqTo(ctx), eqTo(answers))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(returnValue)
   }
 
   def saveConstructionIndustrySubcontractors(ctx: JourneyContextWithNino, answers: ConstructionJourneyAnswers)
                     (returnValue: ApiResultT[Unit]): ScalaOngoingStubbing[ApiResultT[Unit]] = {
     when(mockInstance.saveConstructionIndustrySubcontractors(eqTo(ctx), eqTo(answers))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(returnValue)
   }
 
   def saveProfessionalFees(ctx: JourneyContextWithNino, answers: ProfessionalFeesJourneyAnswers)
                                             (returnValue: ApiResultT[Unit]): ScalaOngoingStubbing[ApiResultT[Unit]] = {
     when(mockInstance.saveProfessionalFees(eqTo(ctx), eqTo(answers))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(returnValue)
   }
 
   def saveFinancialCharges(ctx: JourneyContextWithNino, answers: FinancialChargesJourneyAnswers)
                           (returnValue: ApiResultT[Unit]): ScalaOngoingStubbing[ApiResultT[Unit]] = {
     when(mockInstance.saveFinancialCharges(eqTo(ctx), eqTo(answers))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(returnValue)
   }
 
   def saveBadDebts(ctx: JourneyContextWithNino, answers: IrrecoverableDebtsJourneyAnswers)
                           (returnValue: ApiResultT[Unit]): ScalaOngoingStubbing[ApiResultT[Unit]] = {
     when(mockInstance.saveBadDebts(eqTo(ctx), eqTo(answers))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(returnValue)
   }
 
   def saveDepreciationCosts(ctx: JourneyContextWithNino, answers: DepreciationCostsJourneyAnswers)
                   (returnValue: ApiResultT[Unit]): ScalaOngoingStubbing[ApiResultT[Unit]] = {
     when(mockInstance.saveDepreciationCosts(eqTo(ctx), eqTo(answers))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(returnValue)
   }
 
   def saveOtherExpenses(ctx: JourneyContextWithNino, answers: OtherExpensesJourneyAnswers)
                            (returnValue: ApiResultT[Unit]): ScalaOngoingStubbing[ApiResultT[Unit]] = {
     when(mockInstance.saveOtherExpenses(eqTo(ctx), eqTo(answers))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(returnValue)
   }
 
   def saveInterests(ctx: JourneyContextWithNino, answers: InterestJourneyAnswers)
                        (returnValue: ApiResultT[Unit]): ScalaOngoingStubbing[ApiResultT[Unit]] = {
     when(mockInstance.saveInterests(eqTo(ctx), eqTo(answers))(any[HeaderCarrier]))
-      .thenReturn(EitherT.rightT(returnValue))
+      .thenReturn(returnValue)
   }
 
 }

--- a/test/mocks/services/MockReliefClaimsService.scala
+++ b/test/mocks/services/MockReliefClaimsService.scala
@@ -17,40 +17,41 @@
 package mocks.services
 
 import cats.data.EitherT
-import cats.implicits.catsStdInstancesForFuture
 import models.common.JourneyContextWithNino
 import models.connector.api_1505.ClaimId
 import models.connector.common.ReliefClaim
 import models.domain.ApiResultT
+import models.error.ServiceError
 import models.frontend.adjustments.WhatDoYouWantToDoWithLoss
 import org.mockito.ArgumentMatchers.any
-import org.mockito.ArgumentMatchersSugar.eqTo
-import org.mockito.MockitoSugar.when
-import org.mockito.stubbing.ScalaOngoingStubbing
+import org.mockito.ArgumentMatchers.{`eq` as eqTo}
+import org.mockito.Mockito.when
+import org.mockito.stubbing.OngoingStubbing as ScalaOngoingStubbing
 import org.scalatestplus.mockito.MockitoSugar.mock
 import services.journeyAnswers.{ReliefClaimsService, UpdateReliefClaimsResponse}
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 object MockReliefClaimsService {
   val mockInstance: ReliefClaimsService = mock[ReliefClaimsService]
 
   def getAllReliefClaims(ctx: JourneyContextWithNino)(returnValue: List[ReliefClaim] = Nil): ScalaOngoingStubbing[ApiResultT[List[ReliefClaim]]] =
     when(mockInstance.getAllReliefClaims(eqTo(ctx))(any()))
-      .thenReturn(EitherT.pure(returnValue))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(returnValue)))
 
   def createReliefClaims(ctx: JourneyContextWithNino)(
       returnValue: List[ClaimId] = Nil): ScalaOngoingStubbing[ApiResultT[List[ClaimId]]] =
     when(mockInstance.createReliefClaims(eqTo(ctx), any())(any(), any()))
-      .thenReturn(EitherT.pure(returnValue))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(returnValue)))
 
   def updateReliefClaims(ctx: JourneyContextWithNino, oldAnswers: List[ReliefClaim], newAnswers: WhatDoYouWantToDoWithLoss*)(
       returnValue: UpdateReliefClaimsResponse): ScalaOngoingStubbing[ApiResultT[UpdateReliefClaimsResponse]] =
     when(mockInstance.updateReliefClaims(eqTo(ctx), eqTo(oldAnswers), eqTo(newAnswers))(any()))
-      .thenReturn(EitherT.pure(returnValue))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(returnValue)))
 
   def deleteReliefClaims(ctx: JourneyContextWithNino, answersToDelete: Seq[ReliefClaim]): ScalaOngoingStubbing[ApiResultT[Unit]] =
     when(mockInstance.deleteReliefClaims(eqTo(ctx), eqTo(answersToDelete))(any()))
-      .thenReturn(EitherT.pure(()))
+      .thenReturn(EitherT.right[ServiceError](Future.successful(())))
 
 }

--- a/test/mocks/services/MockTaskListService.scala
+++ b/test/mocks/services/MockTaskListService.scala
@@ -17,10 +17,10 @@
 package mocks.services
 
 import models.common.{Mtditid, TaxYear}
-import models.commonTaskList.{TaskListModel, TaskListSection}
+import models.commonTaskList.TaskListModel
 import models.frontend.TaskList
-import org.mockito.ArgumentMatchersSugar.eqTo
-import org.mockito.MockitoSugar.when
+import org.mockito.ArgumentMatchersSugar.*
+import org.mockito.Mockito.when
 import org.mockito.stubbing.OngoingStubbing
 import org.scalatestplus.mockito.MockitoSugar.mock
 import services.TaskListService
@@ -32,7 +32,7 @@ object MockTaskListService {
   val mockInstance: TaskListService = mock[TaskListService]
 
   def mockBuildCommonTaskList(legacyTaskList: TaskList, taxYear: TaxYear, mtditid: Mtditid)(
-      response: Future[TaskListModel]): OngoingStubbing[TaskListSection] =
+      response: Future[TaskListModel]): OngoingStubbing[Future[TaskListModel]] =
     when(mockInstance.buildTaskList(eqTo(legacyTaskList), eqTo(taxYear), eqTo(mtditid)))
       .thenReturn(response)
 

--- a/test/models/connector/ClaimIdSpec.scala
+++ b/test/models/connector/ClaimIdSpec.scala
@@ -16,11 +16,10 @@
 
 package models.connector
 
-import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatest.wordspec.AnyWordSpecLike
 import play.api.libs.json.{JsString, Json}
 
-class ClaimIdSpec extends AnyWordSpecLike {
+class ClaimIdSpec extends AnyWordSpecLike with org.scalatest.matchers.should.Matchers {
   "ClaimId" must {
     "serialise to json" in {
       val claimId = ClaimId("12345678900")

--- a/test/services/AuditServiceSpec.scala
+++ b/test/services/AuditServiceSpec.scala
@@ -18,7 +18,8 @@ package services
 
 import config.AppConfig
 import org.mockito.ArgumentMatchers.any
-import org.mockito.MockitoSugar
+import org.mockito.Mockito.{reset, times, verify, when}
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
@@ -27,12 +28,11 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.audit.http.connector.AuditResult.{Disabled, Failure, Success}
 import uk.gov.hmrc.play.audit.model.ExtendedDataEvent
-import utils.TestUtils.convertToAnyMustWrapper
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
-class AuditServiceSpec extends AnyFreeSpec with MockitoSugar with BeforeAndAfterEach with ScalaFutures {
+class AuditServiceSpec extends AnyFreeSpec with MockitoSugar with BeforeAndAfterEach with ScalaFutures with org.scalatest.matchers.must.Matchers {
 
   case class Test(data: String)
   val mockAuditConnector: AuditConnector = mock[AuditConnector]

--- a/test/services/BusinessServiceSpec.scala
+++ b/test/services/BusinessServiceSpec.scala
@@ -31,7 +31,7 @@ import models.error.DownstreamError.SingleDownstreamError
 import models.error.ServiceError.BusinessNotFoundError
 import models.error.{DownstreamErrorBody, ServiceError}
 import models.frontend.adjustments.NetBusinessProfitOrLossValues
-import org.mockito.MockitoSugar.when
+import org.mockito.Mockito.when
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike

--- a/test/services/journeyAnswers/ExpensesAnswersServiceSpec.scala
+++ b/test/services/journeyAnswers/ExpensesAnswersServiceSpec.scala
@@ -39,7 +39,7 @@ import models.frontend.expenses.tailoring.ExpensesTailoring.{IndividualCategorie
 import models.frontend.expenses.tailoring.ExpensesTailoringAnswers
 import models.frontend.expenses.tailoring.ExpensesTailoringAnswers.{AsOneTotalAnswers, NoExpensesAnswers}
 import models.frontend.expenses.workplaceRunningCosts.WorkplaceRunningCostsAnswers
-import org.mockito.MockitoSugar.when
+import org.mockito.Mockito.when
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar.mock

--- a/test/services/journeyAnswers/IncomeAnswersServiceImplSpec.scala
+++ b/test/services/journeyAnswers/IncomeAnswersServiceImplSpec.scala
@@ -29,11 +29,10 @@ import models.error.DownstreamErrorBody.SingleDownstreamErrorBody
 import models.error.ServiceError
 import models.error.ServiceError.InvalidJsonFormatError
 import models.frontend.income.IncomeJourneyAnswers
-import org.mockito.IdiomaticMockito.StubbingOps
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
-import org.mockito.Mockito.{times, when}
-import org.mockito.MockitoSugar.{mock, never, verify}
-import org.mockito.matchers.MacroBasedMatchers
+import org.mockito.Mockito.{never, times, verify, when}
+import org.scalatestplus.mockito.MockitoSugar.mock
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.EitherValues._
 import org.scalatest.OptionValues._
@@ -55,7 +54,7 @@ import java.time.Instant
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class IncomeAnswersServiceImplSpec extends AnyWordSpecLike with Matchers with MacroBasedMatchers with BeforeAndAfterEach {
+class IncomeAnswersServiceImplSpec extends AnyWordSpecLike with Matchers with BeforeAndAfterEach {
   implicit val hc: HeaderCarrier = HeaderCarrier()
 
   override def beforeEach(): Unit = {
@@ -101,60 +100,61 @@ class IncomeAnswersServiceImplSpec extends AnyWordSpecLike with Matchers with Ma
     "no period summary or annual submission data exists" must { // businessId, mtditid, nino
       "successfully store data and create the period summary" in new TestCase(connector = mock[IFSConnector]) {
         when(mockBusinessService.getBusiness(any[BusinessId], any[Mtditid], any[Nino])(any[HeaderCarrier]))
-          .thenReturn(EitherT.rightT(BusinessDataBuilder.aBusiness))
+          .thenReturn(EitherT.right[ServiceError](Future.successful(BusinessDataBuilder.aBusiness)))
 
-        connector.listSEPeriodSummary(*)(*, *) returns
-          Future.successful(api1965EmptyResponse.asRight)
+        when(connector.listSEPeriodSummary(any())(any(), any()))
+          .thenReturn(Future.successful(api1965EmptyResponse.asRight))
 
-        connector.createSEPeriodSummary(*)(*, *) returns
-          Future.successful(().asRight)
+        when(connector.createSEPeriodSummary(any())(any(), any()))
+          .thenReturn(Future.successful(().asRight))
 
-        connector.getAnnualSummaries(*)(*, *) returns
-          Future.successful(SingleDownstreamError(NOT_FOUND, SingleDownstreamErrorBody.notFound).asLeft)
+        when(connector.getAnnualSummaries(any())(any(), any()))
+          .thenReturn(Future.successful(SingleDownstreamError(NOT_FOUND, SingleDownstreamErrorBody.notFound).asLeft))
 
-        connector.createUpdateOrDeleteApiAnnualSummaries(*, *)(*, *) returns
-          EitherT.rightT(())
+        when(connector.createUpdateOrDeleteApiAnnualSummaries(any(), any())(any(), any()))
+          .thenReturn(EitherT.right[ServiceError](Future.successful(())))
 
         val answers: IncomeJourneyAnswers = incomeJourneyAnswersGen.sample.get
         val ctx: JourneyContextWithNino   = JourneyContextWithNino(currTaxYear, businessId, mtditid, nino)
 
         service.saveAnswers(ctx, answers).value.futureValue shouldBe ().asRight
 
-        verify(connector, times(1)).createSEPeriodSummary(*)(*, *)
-        verify(auditService, times(1)).sendAuditEvent(*, *)(*, *)
+        verify(connector, times(1)).createSEPeriodSummary(any())(any(), any())
+        verify(auditService, times(1)).sendAuditEvent(any(), any())(any(), any())
         verify(mockBusinessService, times(1)).getBusiness(any[BusinessId], any[Mtditid], any[Nino])(any[HeaderCarrier])
-        verify(connector, never).amendSEPeriodSummary(*)(*, *)
+        verify(connector, never).amendSEPeriodSummary(any())(any(), any())
       }
     }
 
     "prior submission data exists" must {
       "successfully store data and amend the period summary" in new TestCase(connector = mock[IFSConnector]) {
         when(mockBusinessService.getBusiness(any[BusinessId], any[Mtditid], any[Nino])(any[HeaderCarrier]))
-          .thenReturn(EitherT.rightT(BusinessDataBuilder.aBusiness))
+          .thenReturn(EitherT.right[ServiceError](Future.successful(BusinessDataBuilder.aBusiness)))
 
-        connector.listSEPeriodSummary(*)(*, *) returns
-          Future.successful(api1965MatchedResponse.asRight)
+        when(connector.listSEPeriodSummary(any())(any(), any()))
+          .thenReturn(Future.successful(api1965MatchedResponse.asRight))
 
-        connector.getPeriodicSummaryDetail(*)(*, *) returns
-          Future.successful(api1786DeductionsSuccessResponse.asRight)
+        when(connector.getPeriodicSummaryDetail(any())(any(), any()))
+          .thenReturn(Future.successful(api1786DeductionsSuccessResponse.asRight))
 
-        connector.amendSEPeriodSummary(*)(*, *) returns Future.successful(().asRight)
+        when(connector.amendSEPeriodSummary(any())(any(), any()))
+          .thenReturn(Future.successful(().asRight))
 
-        connector.getAnnualSummaries(*)(*, *) returns
-          Future.successful(api1803SuccessResponse.asRight)
+        when(connector.getAnnualSummaries(any())(any(), any()))
+          .thenReturn(Future.successful(api1803SuccessResponse.asRight))
 
-        connector.createUpdateOrDeleteApiAnnualSummaries(*, *)(*, *) returns
-          EitherT.rightT(())
+        when(connector.createUpdateOrDeleteApiAnnualSummaries(any(), any())(any(), any()))
+          .thenReturn(EitherT.right[ServiceError](Future.successful(())))
 
         val answers: IncomeJourneyAnswers = incomeJourneyAnswersGen.sample.get
         val ctx: JourneyContextWithNino   = JourneyContextWithNino(currTaxYear, businessId, mtditid, nino)
 
         service.saveAnswers(ctx, answers).value.futureValue shouldBe ().asRight
 
-        verify(connector, times(1)).amendSEPeriodSummary(*)(*, *)
-        verify(auditService, times(1)).sendAuditEvent(*, *)(*, *)
+        verify(connector, times(1)).amendSEPeriodSummary(any())(any(), any())
+        verify(auditService, times(1)).sendAuditEvent(any(), any())(any(), any())
         verify(mockBusinessService, times(1)).getBusiness(any[BusinessId], any[Mtditid], any[Nino])(any[HeaderCarrier])
-        verify(connector, never).createSEPeriodSummary(*)(*, *)
+        verify(connector, never).createSEPeriodSummary(any())(any(), any())
       }
     }
   }
@@ -162,7 +162,7 @@ class IncomeAnswersServiceImplSpec extends AnyWordSpecLike with Matchers with Ma
   "saveAnswers" should {
     "save data in the repository" in new TestCase() {
       when(mockBusinessService.getBusiness(any[BusinessId], any[Mtditid], any[Nino])(any[HeaderCarrier]))
-        .thenReturn(EitherT.rightT(BusinessDataBuilder.aBusiness))
+        .thenReturn(EitherT.right[ServiceError](Future.successful(BusinessDataBuilder.aBusiness)))
 
       service
         .saveAnswers(journeyCtxWithNino, sampleIncomeJourneyAnswersData)

--- a/test/services/journeyAnswers/PeriodSummaryServiceSpec.scala
+++ b/test/services/journeyAnswers/PeriodSummaryServiceSpec.scala
@@ -87,7 +87,7 @@ class PeriodSummaryServiceSpec extends AnyWordSpec with Matchers with BeforeAndA
     amendBody
   )
 
-  MockIFSConnector.amendSEPeriodSummary()(Right(()))
+  MockIFSConnector.amendSEPeriodSummary()(().asRight)
 
   "get answers" should {
 

--- a/test/services/journeyAnswers/ProfitOrLossAnswersServiceImplSpec.scala
+++ b/test/services/journeyAnswers/ProfitOrLossAnswersServiceImplSpec.scala
@@ -35,8 +35,8 @@ import models.error.DownstreamErrorBody.SingleDownstreamErrorBody
 import models.error.ServiceError
 import models.frontend.adjustments.WhatDoYouWantToDoWithLoss.{CarryItForward, DeductFromOtherTypes}
 import models.frontend.adjustments._
-import org.mockito.ArgumentMatchersSugar.{any, eqTo}
-import org.mockito.MockitoSugar.{reset, times, verify, when}
+import org.mockito.ArgumentMatchers.{any, `eq` as eqTo}
+import org.mockito.Mockito.{reset, times, verify, when}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -54,7 +54,7 @@ import utils.BaseSpec.{businessId, hc, journeyCtxWithNino}
 import utils.EitherTTestOps.convertScalaFuture
 
 import java.time.LocalDateTime
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class ProfitOrLossAnswersServiceImplSpec
@@ -314,7 +314,7 @@ class ProfitOrLossAnswersServiceImplSpec
           getBroughtForwardLossResult = api1502SuccessResponse.asRight
         )
       when(mockBroughtForwardLossConnector.deleteBroughtForwardLoss(any[Nino], any[TaxYear], any[String])(any[HeaderCarrier], any[ExecutionContext]))
-        .thenReturn(EitherT.rightT(Right((): Unit)))
+        .thenReturn(EitherT.right[ServiceError](Future.successful(())))
 
       MockReliefClaimsService.getAllReliefClaims(journeyCtxWithNino)()
 
@@ -421,7 +421,7 @@ class ProfitOrLossAnswersServiceImplSpec
 
     "must return error when the downstream api 'getAllReliefClaims' fails to get the data" in new StubbedService {
 
-      when(mockInstance.getAllReliefClaims(eqTo(journeyCtxWithNino))(any[HeaderCarrier])).thenReturn(EitherT.leftT(downstreamError))
+      when(mockInstance.getAllReliefClaims(eqTo(journeyCtxWithNino))(any[HeaderCarrier])).thenReturn(EitherT.left[List[ReliefClaim]](Future.successful(downstreamError: ServiceError)))
       val result: Either[ServiceError, Option[ProfitOrLossJourneyAnswers]] = service.getProfitOrLoss(journeyCtxWithNino).value.futureValue
 
       assert(result === downstreamError.asLeft)
@@ -666,7 +666,7 @@ class ProfitOrLossAnswersServiceImplSpec
 
         when(
           mockBroughtForwardLossConnector.deleteBroughtForwardLoss(any[Nino], any[TaxYear], any[String])(any[HeaderCarrier], any[ExecutionContext]))
-          .thenReturn(EitherT.rightT(Right((): Unit)))
+          .thenReturn(EitherT.right[ServiceError](Future.successful(())))
 
         val result: Either[ServiceError, Unit] = service
           .storeBroughtForwardLossAnswers(
@@ -685,7 +685,7 @@ class ProfitOrLossAnswersServiceImplSpec
 
         when(
           mockBroughtForwardLossConnector.deleteBroughtForwardLoss(any[Nino], any[TaxYear], any[String])(any[HeaderCarrier], any[ExecutionContext]))
-          .thenReturn(EitherT.rightT(()))
+          .thenReturn(EitherT.right[ServiceError](Future.successful(())))
 
         val result: Either[ServiceError, Unit] =
           service.storeBroughtForwardLossAnswers(journeyCtxWithNino, noBroughtForwardLossAnswers).value.futureValue
@@ -699,7 +699,7 @@ class ProfitOrLossAnswersServiceImplSpec
 
           when(
             mockBroughtForwardLossConnector.deleteBroughtForwardLoss(any[Nino], any[TaxYear], any[String])(any[HeaderCarrier], any[ExecutionContext]))
-            .thenReturn(EitherT.rightT(()))
+            .thenReturn(EitherT.right[ServiceError](Future.successful(())))
 
           override val ifsBusinessDetailsConnector: StubIFSBusinessDetailsConnector =
             StubIFSBusinessDetailsConnector(listBroughtForwardLossesResult = api1870SuccessResponse.asRight)
@@ -765,7 +765,7 @@ class ProfitOrLossAnswersServiceImplSpec
 
         when(
           mockBroughtForwardLossConnector.deleteBroughtForwardLoss(any[Nino], any[TaxYear], any[String])(any[HeaderCarrier], any[ExecutionContext]))
-          .thenReturn(EitherT.leftT(downstreamError))
+          .thenReturn(EitherT.left[Unit](Future.successful(downstreamError: ServiceError)))
 
         val result: Either[ServiceError, Unit] = service
           .storeBroughtForwardLossAnswers(
@@ -784,7 +784,7 @@ class ProfitOrLossAnswersServiceImplSpec
 
         when(
           mockBroughtForwardLossConnector.deleteBroughtForwardLoss(any[Nino], any[TaxYear], any[String])(any[HeaderCarrier], any[ExecutionContext]))
-          .thenReturn(EitherT.leftT(downstreamError))
+          .thenReturn(EitherT.left[Unit](Future.successful(downstreamError: ServiceError)))
 
         val res: ApiResultT[Unit] =
           service.storeBroughtForwardLossAnswers(journeyCtxWithNino, noBroughtForwardLossAnswers)
@@ -799,7 +799,7 @@ class ProfitOrLossAnswersServiceImplSpec
 
           when(
             mockBroughtForwardLossConnector.deleteBroughtForwardLoss(any[Nino], any[TaxYear], any[String])(any[HeaderCarrier], any[ExecutionContext]))
-            .thenReturn(EitherT.leftT(downstreamError))
+            .thenReturn(EitherT.left[Unit](Future.successful(downstreamError: ServiceError)))
 
           override val ifsBusinessDetailsConnector: StubIFSBusinessDetailsConnector =
             StubIFSBusinessDetailsConnector(listBroughtForwardLossesResult = api1870SuccessResponse.asRight)

--- a/test/services/journeyAnswers/ReliefClaimsServiceSpec.scala
+++ b/test/services/journeyAnswers/ReliefClaimsServiceSpec.scala
@@ -27,8 +27,8 @@ import models.connector.common.{ReliefClaim, UkProperty}
 import models.error.ServiceError
 import models.frontend.adjustments._
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.times
-import org.mockito.MockitoSugar.{mock, reset, verify, when}
+import org.mockito.Mockito.{reset, times, verify, when}
+import org.scalatestplus.mockito.MockitoSugar.mock
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike

--- a/test/stubs/package.scala
+++ b/test/stubs/package.scala
@@ -27,5 +27,5 @@ import scala.concurrent.Future
 package object stubs {
   val downstreamError: SingleDownstreamError = SingleDownstreamError(INTERNAL_SERVER_ERROR, SingleDownstreamErrorBody.serviceUnavailable)
   def serviceUnitT: ApiResultT[Unit]         = EitherT.right[ServiceError](Future.successful(()))
-  def serviceErrorT: ApiResultT[Unit]        = EitherT.leftT(downstreamError)
+  def serviceErrorT: ApiResultT[Unit]        = EitherT.left[Unit](Future.successful(downstreamError: ServiceError))
 }

--- a/test/utils/BaseSpec.scala
+++ b/test/utils/BaseSpec.scala
@@ -20,7 +20,6 @@ import data.TimeData
 import models.common.JourneyName.TradeDetails
 import models.common._
 import models.database.JourneyAnswers
-import org.mockito.ArgumentMatchersSugar
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
@@ -31,7 +30,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.ExecutionContext
 
-trait BaseSpec extends AnyWordSpec with MockitoSugar with ArgumentMatchersSugar with ScalaFutures {
+trait BaseSpec extends AnyWordSpec with MockitoSugar with ScalaFutures {
 
   protected implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
   protected implicit val hc: HeaderCarrier    = HeaderCarrier()

--- a/test/utils/PlayJsonEnumSpec.scala
+++ b/test/utils/PlayJsonEnumSpec.scala
@@ -21,15 +21,17 @@ import enumeratum._
 import play.api.libs.json._
 import cats.implicits._
 
+// Defined at file scope so enumeratum's findValues macro works correctly in Scala 3
+sealed trait Foo extends EnumEntry
+
+object Foo extends Enum[Foo] with utils.PlayJsonEnum[Foo] {
+  override def values: IndexedSeq[Foo] = findValues
+
+  case object FooOne extends Foo
+  case object FooTwo extends Foo
+}
+
 class PlayJsonEnumSpec extends AnyWordSpecLike {
-  sealed trait Foo extends EnumEntry
-
-  object Foo extends Enum[Foo] with utils.PlayJsonEnum[Foo] {
-    override def values: IndexedSeq[Foo] = findValues
-
-    case object FooOne extends Foo
-    case object FooTwo extends Foo
-  }
 
   "PlayJsonEnum" should {
     "serialize enum values to JSON" in {

--- a/test/utils/TestUtils.scala
+++ b/test/utils/TestUtils.scala
@@ -84,16 +84,16 @@ trait TestUtils extends AnyWordSpec with Matchers with MockFactory with GuiceOne
       Enrolment(EnrolmentKeys.nino, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.nino, testNino)), "Activated")
     ))
 
-  def mockAuth(enrolments: Enrolments = individualEnrolments): CallHandler4[Predicate, Retrieval[_], HeaderCarrier, ExecutionContext, Future[Any]] = {
+  def mockAuth(enrolments: Enrolments = individualEnrolments): CallHandler4[Predicate, Retrieval[Any], HeaderCarrier, ExecutionContext, Future[Any]] = {
 
     (mockAuthConnector
-      .authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-      .expects(*, Retrievals.affinityGroup, *, *)
+      .authorise(_: Predicate, _: Retrieval[Any])(_: HeaderCarrier, _: ExecutionContext))
+      .expects(*, Retrievals.affinityGroup.asInstanceOf[Retrieval[Any]], *, *)
       .returning(Future.successful(Some(AffinityGroup.Individual)))
 
     (mockAuthConnector
-      .authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-      .expects(*, Retrievals.allEnrolments and Retrievals.confidenceLevel, *, *)
+      .authorise(_: Predicate, _: Retrieval[Any])(_: HeaderCarrier, _: ExecutionContext))
+      .expects(*, (Retrievals.allEnrolments and Retrievals.confidenceLevel).asInstanceOf[Retrieval[Any]], *, *)
       .returning(Future.successful(enrolments and ConfidenceLevel.L250))
   }
 
@@ -104,22 +104,22 @@ trait TestUtils extends AnyWordSpec with Matchers with MockFactory with GuiceOne
     ))
 
   def mockAuthAsAgent(
-      enrolments: Enrolments = agentEnrolments): CallHandler4[Predicate, Retrieval[_], HeaderCarrier, ExecutionContext, Future[Any]] = {
+      enrolments: Enrolments = agentEnrolments): CallHandler4[Predicate, Retrieval[Any], HeaderCarrier, ExecutionContext, Future[Any]] = {
 
     (mockAuthConnector
-      .authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-      .expects(*, Retrievals.affinityGroup, *, *)
+      .authorise(_: Predicate, _: Retrieval[Any])(_: HeaderCarrier, _: ExecutionContext))
+      .expects(*, Retrievals.affinityGroup.asInstanceOf[Retrieval[Any]], *, *)
       .returning(Future.successful(Some(AffinityGroup.Agent)))
 
     (mockAuthConnector
-      .authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-      .expects(*, Retrievals.allEnrolments, *, *)
+      .authorise(_: Predicate, _: Retrieval[Any])(_: HeaderCarrier, _: ExecutionContext))
+      .expects(*, Retrievals.allEnrolments.asInstanceOf[Retrieval[Any]], *, *)
       .returning(Future.successful(enrolments))
   }
 
-  def mockAuthReturnException(exception: Exception): CallHandler4[Predicate, Retrieval[_], HeaderCarrier, ExecutionContext, Future[Any]] =
+  def mockAuthReturnException(exception: Exception): CallHandler4[Predicate, Retrieval[Any], HeaderCarrier, ExecutionContext, Future[Any]] =
     (mockAuthConnector
-      .authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
+      .authorise(_: Predicate, _: Retrieval[Any])(_: HeaderCarrier, _: ExecutionContext))
       .expects(*, *, *, *)
       .returning(Future.failed(exception))
 


### PR DESCRIPTION
Migrates the service from Scala 2.13.18 to Scala 3.3.5 LTS. All unit tests (641) and integration test compilation pass.

## Build changes

- `build.sbt`: bump `scalaVersion` to `"3.3.5"`
- Compiler flags: rename `-Ywarn-*` → `-W*`, remove `-Wunused:patvars` (not a valid Scala 3 flag), update `Def.Setting[_]` → `Def.Setting[?]`
- `project/CodeCoverageSettings.scala`: `Setting[_]` → `Setting[?]`
- `project/AppDependencies.scala`: replace `mockito-scala-scalatest 2.1.0` (no `_3` artifact) with `2.2.1` which ships full Scala 3 support including value-class-aware `eqTo` macros

## App source fixes

- Lambda parameter parens: `{ x: T => ... }` → `{ (x: T) => ... }` in `ErrorType`, `ServiceError`, `AuditService`
- WSBodyWritables: add `import play.api.libs.ws.WSBodyWritables.writeableOf_JsValue` to `connectors/package.scala` and `HipReliefClaimsConnector` (needed in Scala 3)
- `TaskListData`: replace `unlift(TaskListData.unapply)` with an explicit lambda — Scala 3 case class `unapply` is transparent, returning the case class itself rather than `Option[...]`
- `Writes.enumNameWrites[this.type]`: doesn't compile for `scala.Enumeration` subobjects in Scala 3; replaced with `Writes[Value](v => JsString(v.toString))` in `AnnualNonFinancialsType`, `LatencyDetails` (×2), and `UkAddressType`
- `MongoJourneyAnswersRepository`: `.expireAfter(appConfig.mongoTTL, ...)` → `.expireAfter(appConfig.mongoTTL.toLong, ...)` — `Int` no longer widens automatically to `Long` for Java method calls in Scala 3
- `JourneyAnswerValidationService`: `Json.toJson(value)` on a generic `A` doesn't resolve the implicit `Writes[A]` in Scala 3; replaced with explicit `Json.toJson(value)(format)`

## Unit test fixes

- Removed `ArgumentMatchersSugar` mixin from `BaseSpec` (conflicts with standard mockito when mockito-scala is absent); re-added once 2.2.1 restored
- Mock helpers (`MockBusinessService`, `MockIFSBusinessDetailsConnector`, `MockBusinessDetailsConnector`, `MockIncomeSourcesConnector`, `MockJourneyAnswersRepository`, `MockExpensesAnswersService`, `MockTaskListService`): replaced `import org.mockito.ArgumentMatchers.{any, eq as eqTo}` with `import org.mockito.ArgumentMatchersSugar.*` so that `eqTo` uses the mockito-scala macro which correctly unboxes Scala value classes before matcher registration (standard `ArgumentMatchers.eq` boxes AnyVal types causing match failures at runtime)
- `EitherT.rightT`/`.pure` → `EitherT.right[ServiceError](Future.successful(...))` and `EitherT.leftT` → `EitherT.left[T](Future.successful(...))` in several mock/service spec files (Scala 3 stricter type inference on `Nothing` for invariant `EitherT`)
- `Retrieval[_]` → `Retrieval[Any]` in `TestUtils` and `AuthorisedActionSpec` (capture-conversion skolem error in Scala 3)
- `PlayJsonEnumSpec`: moved inner `sealed trait Foo`/`object Foo` to file scope — enumeratum's `findValues` macro requires top-level definitions in Scala 3
- Fixed 3 controller tests (`clearOtherExpenses`, `clearFinancialCharge`, `clearInterestOnBank`) that had copy-paste bugs exposing a Scala 2 cats `Functor[Tuple2]` quirk masking the failure

## Integration test fixes

- Remove invalid `import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper` (not a member of the `Matchers` object in Scala 3); `PlaySpec` already mixes in `must.Matchers`, so assertions changed to `mustBe`/`must include`
- `MockTimeMachine`: add missing `import org.mockito.Mockito.when`
- `repositories/package.scala` and `JourneyAnswersHelper`: add `import org.mongodb.scala._` to bring the `toFuture()` extension method into scope for `SingleObservable` and `FindObservable`
- `MongoJourneyAnswersRepositoryISpec`: add explicit type annotation `override val repository: MongoJourneyAnswersRepository` so the override satisfies `MongoTestSupport[JourneyAnswers]` which declares the field as `PlayMongoRepository[A]`
- Controller ISpecs: add `import play.api.libs.ws.{DefaultBodyWritables, JsonBodyWritables}._` for `WSRequest.put(JsValue)` / `.post(JsValue)` body implicit resolution
- `BusinessDetailsControllerISpec`: add `import play.api.libs.ws.DefaultBodyReadables.readableAsString` to resolve `res.body` ambiguity
- `WhichYearIsLossReportedSpec`: replace `utils.TestUtils.convertToAnyMustWrapper` import with `with org.scalatest.matchers.must.Matchers`